### PR TITLE
Fixing timeout on DNS, and SNI support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,7 @@ val json4sVersion = "3.2.11"
 val scalaTestVersion = "2.2.4"
 val scalaMockVersion = "3.2"
 
+libraryDependencies += "com.ning" % "async-http-client" % "1.9.38"
 libraryDependencies += "net.databinder.dispatch" %% "dispatch-core" % dispatchVersion
 libraryDependencies += "net.databinder.dispatch" %% "dispatch-json4s-native" % dispatchVersion
 

--- a/src/main/scala/algolia/DispatchHttpClient.scala
+++ b/src/main/scala/algolia/DispatchHttpClient.scala
@@ -32,19 +32,23 @@ import org.json4s._
 import scala.concurrent.ExecutionContext
 
 object default {
-  val httpReadTimeout = 30000
+  val httpReadTimeout = 2000
 
   //httpSocketTimeout in HttpClient
   val httpConnectTimeout = 2000
+
+  val httpRequestTimeout = 2000
 }
 
 object DispatchHttpClient extends DispatchHttpClient(
   httpReadTimeout = default.httpReadTimeout,
-  httpConnectTimeout = default.httpConnectTimeout
+  httpConnectTimeout = default.httpConnectTimeout,
+  httpRequestTimeout = default.httpRequestTimeout
 )
 
 case class DispatchHttpClient(httpReadTimeout: Int = default.httpReadTimeout,
-                              httpConnectTimeout: Int = default.httpConnectTimeout) {
+                              httpConnectTimeout: Int = default.httpConnectTimeout,
+                              httpRequestTimeout: Int = default.httpRequestTimeout) {
 
   implicit val formats: Formats = AlgoliaDsl.formats
 
@@ -52,6 +56,7 @@ case class DispatchHttpClient(httpReadTimeout: Int = default.httpReadTimeout,
     builder
       .setConnectTimeout(httpConnectTimeout)
       .setReadTimeout(httpReadTimeout)
+      .setRequestTimeout(httpRequestTimeout)
   }
 
   def request[T: Manifest](host: String, headers: Map[String, String], payload: HttpPayload)(implicit executor: ExecutionContext): Future[T] = {

--- a/src/main/scala/algolia/definitions/ListIndexesDefinition.scala
+++ b/src/main/scala/algolia/definitions/ListIndexesDefinition.scala
@@ -32,7 +32,11 @@ import scala.concurrent.{ExecutionContext, Future}
 
 case class ListIndexesDefinition() extends Definition {
 
-  override private[algolia] def build() = HttpPayload(GET, Seq("1", "indexes"))
+  override private[algolia] def build() = HttpPayload(
+    GET,
+    Seq("1", "indexes"),
+    isSearch = true
+  )
 
 }
 


### PR DESCRIPTION
Change the default httpReadTimeout from 30s to 2s.

Closes #96