### PR TITLE
Specify UTF-8 character set in Content-Type request header

### DIFF
--- a/src/main/scala/algolia/AlgoliaClient.scala
+++ b/src/main/scala/algolia/AlgoliaClient.scala
@@ -72,7 +72,7 @@ class AlgoliaClient(applicationId: String, apiKey: String) {
     "X-Algolia-Application-Id" -> applicationId,
     "X-Algolia-API-Key" -> apiKey,
     "User-Agent" -> userAgent,
-    "Content-type" -> "application/json",
+    "Content-Type" -> "application/json; charset=UTF-8",
     "Accept" -> "application/json"
   )
 

--- a/src/test/scala/algolia/AlgoliaClientTest.scala
+++ b/src/test/scala/algolia/AlgoliaClientTest.scala
@@ -52,6 +52,10 @@ class AlgoliaClientTest extends AlgoliaTest {
       apiClient.userAgent should (startWith("Algolia for Scala 2.11") and include("API 1."))
     }
 
+    it("should set Content-Type header") {
+      apiClient.headers should contain("Content-Type" -> "application/json; charset=UTF-8")
+    }
+
     it("should set indexing hosts") {
       apiClient.indexingHosts should equal(Seq(
         "https://APPID.algolia.net",

--- a/src/test/scala/algolia/integration/IndicesIntegrationTest.scala
+++ b/src/test/scala/algolia/integration/IndicesIntegrationTest.scala
@@ -55,6 +55,22 @@ class IndicesIntegrationTest extends AlgoliaTest {
     taskShouldBeCreatedAndWaitForIt(create, "index1")
   }
 
+  it("should index UTF-8 strings") {
+    val create: Future[TaskIndexing] = client.execute {
+      index into "index1" `object` Obj("Bézier")
+    }
+
+    taskShouldBeCreatedAndWaitForIt(create, "index1")
+
+    val query: Future[SearchResult] = client.execute {
+      search into "index1" query Query(query = Some("Bézier"))
+    }
+
+    whenReady(query) { result =>
+      result.as[Obj].map(_.name) should contain("Bézier")
+    }
+  }
+
   it("should list indices") {
     val create: Future[TasksMultipleIndex] = client.execute {
       batch(


### PR DESCRIPTION
Without specifying the `charset`, the search client was failing to index UTF-8 strings (such as "Bézier").

I would love to see this fix in a 1.7.1 release. Thanks!