### PR TITLE
Minor build clean up: use isSnapshot and sbt helpers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -126,11 +126,10 @@ pomExtra := {
 }
 
 publishTo := {
-  val nexus = "https://oss.sonatype.org/"
-  if (version.value.trim.endsWith("SNAPSHOT")) {
-    Some("snapshots" at nexus + "content/repositories/snapshots")
+  if (isSnapshot.value) {
+    Some(Opts.resolver.sonatypeSnapshots)
   } else {
-    Some("releases" at nexus + "service/local/staging/deploy/maven2")
+    Some(Opts.resolver.sonatypeStaging)
   }
 }
 


### PR DESCRIPTION
This PR makes minor changes to the sbt build to take advantage of some helpers from sbt and to use the `isSnapshot` setting key (which boils down to `version.endsWith("-SNAPSHOT")` in the end).