### PR TITLE
bump json4s version from 3.4.0 to 3.5.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ ScoverageSbtPlugin.ScoverageKeys.coverageHighlighting := false //setting to true
 
 val asyncHttpClientVersion = "2.0.4"
 
-val json4sVersion = "3.5.0"
+val json4sVersion = "3.5.2"
 
 val scalaTestVersion = "2.2.6"
 val scalaMockVersion = "3.2"

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ ScoverageSbtPlugin.ScoverageKeys.coverageHighlighting := false //setting to true
 
 val asyncHttpClientVersion = "2.0.4"
 
-val json4sVersion = "3.4.0"
+val json4sVersion = "3.5.0"
 
 val scalaTestVersion = "2.2.6"
 val scalaMockVersion = "3.2"


### PR DESCRIPTION
This was causing an incompatibility for us - would love to not have to shade the algolia library or independently manage a fork to deal with it. Any reason we couldn't increase to the latest json4s version?