### PR TITLE
Add tasks status definition + use HashedWheelTimer in waitFor

### DIFF
--- a/src/main/scala/algolia/AlgoliaDsl.scala
+++ b/src/main/scala/algolia/AlgoliaDsl.scala
@@ -53,6 +53,7 @@ trait AlgoliaDsl
     with SearchDsl
     with SynonymsDsl
     with WaitForTaskDsl
+    with TaskStatusDsl
 
 object AlgoliaDsl extends AlgoliaDsl {
 

--- a/src/main/scala/algolia/definitions/TaskStatusDefinition.scala
+++ b/src/main/scala/algolia/definitions/TaskStatusDefinition.scala
@@ -52,11 +52,10 @@ trait TaskStatusDsl {
       TaskStatusDefinition(task.idToWaitFor())
   }
 
-  implicit object TaskStatusExecutable
-    extends Executable[TaskStatusDefinition, TaskStatus] {
+  implicit object TaskStatusExecutable extends Executable[TaskStatusDefinition, TaskStatus] {
 
     override def apply(client: AlgoliaClient, query: TaskStatusDefinition)(
-      implicit executor: ExecutionContext): Future[TaskStatus] = {
+        implicit executor: ExecutionContext): Future[TaskStatus] = {
       client.request[TaskStatus](query.build())
     }
 

--- a/src/main/scala/algolia/definitions/TaskStatusDefinition.scala
+++ b/src/main/scala/algolia/definitions/TaskStatusDefinition.scala
@@ -1,0 +1,65 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Algolia
+ * http://www.algolia.com/
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package algolia.definitions
+
+import algolia.http.{GET, HttpPayload}
+import algolia.responses.{AlgoliaTask, TaskStatus}
+import algolia.{AlgoliaClient, Executable}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+case class TaskStatusDefinition(taskId: Long, index: Option[String] = None) extends Definition {
+
+  def from(index: String): TaskStatusDefinition = copy(index = Some(index))
+
+  override private[algolia] def build(): HttpPayload = {
+    HttpPayload(
+      GET,
+      Seq("1", "indexes") ++ index ++ Seq("task", taskId.toString),
+      isSearch = true
+    )
+  }
+
+}
+
+trait TaskStatusDsl {
+
+  case object getStatus {
+    def task(task: AlgoliaTask): TaskStatusDefinition =
+      TaskStatusDefinition(task.idToWaitFor())
+  }
+
+  implicit object TaskStatusExecutable
+    extends Executable[TaskStatusDefinition, TaskStatus] {
+
+    override def apply(client: AlgoliaClient, query: TaskStatusDefinition)(
+      implicit executor: ExecutionContext): Future[TaskStatus] = {
+      client.request[TaskStatus](query.build())
+    }
+
+  }
+
+}

--- a/src/main/scala/algolia/definitions/WaitForTaskDefinition.scala
+++ b/src/main/scala/algolia/definitions/WaitForTaskDefinition.scala
@@ -60,7 +60,7 @@ trait WaitForTaskDsl {
   implicit object WaitForTaskDefinitionExecutable
       extends Executable[WaitForTaskDefinition, TaskStatus] {
 
-    // Run every 50 ms, use a wheel with 512 buckets
+    // Run every 100 ms, use a wheel with 512 buckets
     private lazy val timer = {
       val threadFactory = new ThreadFactory {
         override def newThread(r: Runnable): Thread = {
@@ -70,7 +70,7 @@ trait WaitForTaskDsl {
           t
         }
       }
-      new HashedWheelTimer(threadFactory, 50, TimeUnit.MILLISECONDS, 512)
+      new HashedWheelTimer(threadFactory, 100, TimeUnit.MILLISECONDS, 512)
     }
 
     /**

--- a/src/test/scala/algolia/AlgoliaTest.scala
+++ b/src/test/scala/algolia/AlgoliaTest.scala
@@ -68,7 +68,7 @@ class AlgoliaTest
       result
     }
   }
-  
+
   def taskShouldBeCreatedAndWaitForIt(task: Future[AlgoliaTask], index: String)(
       implicit ec: ExecutionContext): Unit = {
     val t: AlgoliaTask = taskShouldBeCreated(task)

--- a/src/test/scala/algolia/dsl/TaskStatusTest.scala
+++ b/src/test/scala/algolia/dsl/TaskStatusTest.scala
@@ -1,0 +1,55 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Algolia
+ * http://www.algolia.com/
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package algolia.dsl
+
+import algolia.AlgoliaDsl._
+import algolia.AlgoliaTest
+import algolia.http.{GET, HttpPayload}
+import algolia.responses.Task
+
+
+
+class TaskStatusTest extends AlgoliaTest {
+
+  describe("get task status") {
+
+    it("get the status of a task") {
+      getStatus task Task(1L, None) from "toto"
+    }
+
+    it("should call API") {
+      (getStatus task Task(1L, None) from "toto").build() should be(
+        HttpPayload(
+          GET,
+          Seq("1", "indexes", "toto", "task", "1"),
+          isSearch = true
+        )
+      )
+    }
+  }
+
+}
+

--- a/src/test/scala/algolia/dsl/TaskStatusTest.scala
+++ b/src/test/scala/algolia/dsl/TaskStatusTest.scala
@@ -30,8 +30,6 @@ import algolia.AlgoliaTest
 import algolia.http.{GET, HttpPayload}
 import algolia.responses.Task
 
-
-
 class TaskStatusTest extends AlgoliaTest {
 
   describe("get task status") {
@@ -52,4 +50,3 @@ class TaskStatusTest extends AlgoliaTest {
   }
 
 }
-

--- a/src/test/scala/algolia/integration/TaskStatusIntegrationTest.scala
+++ b/src/test/scala/algolia/integration/TaskStatusIntegrationTest.scala
@@ -1,0 +1,73 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Algolia
+ * http://www.algolia.com/
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package algolia.integration
+
+import algolia.AlgoliaDsl._
+import algolia.AlgoliaTest
+import algolia.responses.{TaskIndexing, TasksMultipleIndex}
+
+import scala.concurrent.Future
+
+class TaskStatusIntegrationTest extends AlgoliaTest {
+
+  after {
+    clearIndices("indexToGetTaskStatus")
+  }
+
+  it("should get the status of a single object task") {
+    val create: Future[TaskIndexing] = client.execute {
+        index into "indexToGetTaskStatus" `object` ObjectToGet("1", "toto")
+    }
+
+    val task = taskShouldBeCreated(create)
+
+    eventually {
+      val status = client.execute { getStatus task task from "indexToGetTaskStatus" }
+      whenReady(status) { result =>
+        result.status == "published"
+      }
+    }
+  }
+
+  it("should get the status of a multiple objects task") {
+    val create: Future[TasksMultipleIndex] = client.execute {
+      batch(
+        index into "indexToGetTaskStatus" `object` ObjectToGet("1", "toto"),
+        index into "indexToGetTaskStatus" `object` ObjectToGet("2", "tata")
+      )
+    }
+
+    val task = taskShouldBeCreated(create)
+
+    eventually {
+      val status = client.execute { getStatus task task from "indexToGetTaskStatus" }
+      whenReady(status) { result =>
+        result.status == "published"
+      }
+    }
+  }
+
+}

--- a/src/test/scala/algolia/integration/TaskStatusIntegrationTest.scala
+++ b/src/test/scala/algolia/integration/TaskStatusIntegrationTest.scala
@@ -47,7 +47,7 @@ class TaskStatusIntegrationTest extends AlgoliaTest {
     eventually {
       val status = client.execute { getStatus task task from "indexToGetTaskStatus" }
       whenReady(status) { result =>
-        result.status == "published"
+        result.status shouldBe "published"
       }
     }
   }
@@ -65,7 +65,7 @@ class TaskStatusIntegrationTest extends AlgoliaTest {
     eventually {
       val status = client.execute { getStatus task task from "indexToGetTaskStatus" }
       whenReady(status) { result =>
-        result.status == "published"
+        result.status shouldBe "published"
       }
     }
   }

--- a/src/test/scala/algolia/integration/TaskStatusIntegrationTest.scala
+++ b/src/test/scala/algolia/integration/TaskStatusIntegrationTest.scala
@@ -39,7 +39,7 @@ class TaskStatusIntegrationTest extends AlgoliaTest {
 
   it("should get the status of a single object task") {
     val create: Future[TaskIndexing] = client.execute {
-        index into "indexToGetTaskStatus" `object` ObjectToGet("1", "toto")
+      index into "indexToGetTaskStatus" `object` ObjectToGet("1", "toto")
     }
 
     val task = taskShouldBeCreated(create)


### PR DESCRIPTION
This PR makes two changes:

- Adds a `TaskStatusDefinition` to simply query the status of task without waiting for it
- In the `WaitForTaskDefinition`, replaces the creation of `Timer` with a `HashedWheelTimer`

The motivation of the first change is to allow the caller to handle the retries (if any) instead of imposing a strategy. It also allows **not** to create a new `Timer` (and therefore a new `Thread`) for each call.

The motivation of the second change is to allow multiple `waitFors` without creating new timer `Threads` for each one. 

At [Flow](https://github.com/flowcommerce), we ran into issues while checking the status of multiple index tasks with aggressive `baseDelay` as it ended up creating several thousands of `Threads`. The recursive implementation of the `WaitForTaskDsl.request` allows for the creation of several `Threads` per `waitFor` call. In our case, it lead to `java.lang.OutOfMemoryError: unable to create new native thread`.

I understand we do not want to encourage clients to issue thousand of calls at once but again in our case, a few `waitFors` with short `baseDelay` lead to the creation of several thousands threads and eventually to a painful death ;-)

Since extreme time precision is not a requirement, the proposed solution therefore uses a `HashedWheelTimer` with a tick duration of 50ms. This number is roughly in the order of a network round trip. That would allow to defer the calls to the underlying http client.

Please feel free to modify :)

