### PR TITLE
fix: Prevent saving a rule with an empty objectID

### DIFF
--- a/src/main/scala/algolia/dsl/RulesDsl.scala
+++ b/src/main/scala/algolia/dsl/RulesDsl.scala
@@ -28,7 +28,7 @@ package algolia.dsl
 import algolia.definitions._
 import algolia.objects.Rule
 import algolia.responses.{SearchRuleResult, Task}
-import algolia.{AlgoliaClient, Executable}
+import algolia.{AlgoliaClient, AlgoliaClientException, Executable}
 import org.json4s.Formats
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -68,6 +68,9 @@ trait RulesDsl {
 
     override def apply(client: AlgoliaClient, query: SaveRuleDefinition)(
         implicit executor: ExecutionContext): Future[Task] = {
+      if (query.rule.objectID.isEmpty) {
+        return Future.failed(new AlgoliaClientException(s"rule's 'objectID' cannot be empty"))
+      }
       client.request[Task](query.build())
     }
 

--- a/src/test/scala/algolia/integration/RulesIntegrationTest.scala
+++ b/src/test/scala/algolia/integration/RulesIntegrationTest.scala
@@ -27,7 +27,7 @@ package algolia.integration
 
 import algolia.AlgoliaDsl._
 import algolia.objects._
-import algolia.{AlgoliaDsl, AlgoliaTest}
+import algolia.{AlgoliaClientException, AlgoliaDsl, AlgoliaTest}
 
 class RulesIntegrationTest extends AlgoliaTest {
 
@@ -59,6 +59,19 @@ class RulesIntegrationTest extends AlgoliaTest {
       whenReady(r) { res =>
         res.objectID should be("rule1")
         res.description shouldBe Some("rule1")
+      }
+    }
+
+    it("should not save a rule with empty objectID") {
+      val f = client.execute {
+        save rule generateRule("") inIndex indexName
+      }
+
+      whenReady(f.failed) { res =>
+        res shouldBe an[AlgoliaClientException]
+        res
+          .asInstanceOf[AlgoliaClientException]
+          .getMessage shouldBe "rule's 'objectID' cannot be empty"
       }
     }
 


### PR DESCRIPTION
Follow up of https://github.com/algolia/algoliasearch-client-go/issues/397.