### PR TITLE
Fix: objectID is required to deleteObject

### DIFF
--- a/src/main/scala/algolia/definitions/DeleteDefinition.scala
+++ b/src/main/scala/algolia/definitions/DeleteDefinition.scala
@@ -44,7 +44,9 @@ case class DeleteObjectDefinition(
   def index(ind: String): DeleteObjectDefinition = copy(index = Some(ind))
 
   def objectId(objectId: String): DeleteObjectDefinition =
-    copy(oid = Some(objectId))
+    if (objectId.trim.isEmpty)
+      throw new IllegalArgumentException("objectID can't be empty or whitespaces")
+    else copy(oid = Some(objectId))
 
   def objectIds(objectIds: Traversable[String]): BatchDefinition =
     BatchDefinition(objectIds.map { oid =>
@@ -57,11 +59,14 @@ case class DeleteObjectDefinition(
   override def options(requestOptions: RequestOptions): DeleteObjectDefinition =
     copy(requestOptions = Some(requestOptions))
 
-  override private[algolia] def build(): HttpPayload =
+  override private[algolia] def build(): HttpPayload = {
+    if (oid == None) throw new IllegalArgumentException("ObjectID can't None")
+
     HttpPayload(http.DELETE,
                 Seq("1", "indexes") ++ index ++ oid,
                 isSearch = false,
                 requestOptions = requestOptions)
+  }
 }
 
 case class DeleteIndexDefinition(index: String, requestOptions: Option[RequestOptions] = None)

--- a/src/main/scala/algolia/definitions/DeleteDefinition.scala
+++ b/src/main/scala/algolia/definitions/DeleteDefinition.scala
@@ -33,7 +33,7 @@ import org.json4s.native.Serialization.write
 
 case class DeleteObjectDefinition(
     index: Option[String] = None,
-    oid: Option[String] = None,
+    objectId: Option[String] = None,
     requestOptions: Option[RequestOptions] = None)(implicit val formats: Formats)
     extends Definition {
 
@@ -46,7 +46,7 @@ case class DeleteObjectDefinition(
   def objectId(objectId: String): DeleteObjectDefinition =
     if (objectId.trim.isEmpty)
       throw new IllegalArgumentException("objectID can't be empty or whitespaces")
-    else copy(oid = Some(objectId))
+    else copy(objectId = Some(objectId))
 
   def objectIds(objectIds: Traversable[String]): BatchDefinition =
     BatchDefinition(objectIds.map { oid =>
@@ -60,10 +60,10 @@ case class DeleteObjectDefinition(
     copy(requestOptions = Some(requestOptions))
 
   override private[algolia] def build(): HttpPayload = {
-    if (oid == None) throw new IllegalArgumentException("ObjectID can't None")
+    if (objectId == None) throw new IllegalArgumentException("ObjectID can't None")
 
     HttpPayload(http.DELETE,
-                Seq("1", "indexes") ++ index ++ oid,
+                Seq("1", "indexes") ++ index ++ objectId,
                 isSearch = false,
                 requestOptions = requestOptions)
   }

--- a/src/main/scala/algolia/dsl/DeleteDsl.scala
+++ b/src/main/scala/algolia/dsl/DeleteDsl.scala
@@ -44,7 +44,7 @@ trait DeleteDsl {
 
     //Object
     def objectId(objectId: String) =
-      DeleteObjectDefinition(oid = Some(objectId))
+      DeleteObjectDefinition(objectId = Some(objectId))
 
     //Object
     def from(index: String) = DeleteObjectDefinition(index = Some(index))

--- a/src/test/scala/algolia/dsl/DeleteObjectTest.scala
+++ b/src/test/scala/algolia/dsl/DeleteObjectTest.scala
@@ -26,7 +26,7 @@
 package algolia.dsl
 
 import algolia.AlgoliaDsl._
-import algolia.{AlgoliaTest}
+import algolia.AlgoliaTest
 import algolia.http.{DELETE, HttpPayload, POST}
 
 class DeleteObjectTest extends AlgoliaTest {

--- a/src/test/scala/algolia/dsl/DeleteObjectTest.scala
+++ b/src/test/scala/algolia/dsl/DeleteObjectTest.scala
@@ -26,7 +26,7 @@
 package algolia.dsl
 
 import algolia.AlgoliaDsl._
-import algolia.AlgoliaTest
+import algolia.{AlgoliaTest}
 import algolia.http.{DELETE, HttpPayload, POST}
 
 class DeleteObjectTest extends AlgoliaTest {
@@ -39,6 +39,18 @@ class DeleteObjectTest extends AlgoliaTest {
 
     it("deletes object with inverse DSL") {
       delete objectId "oid" from "toto"
+    }
+
+    it("deletes object empty objectId") {
+      the[IllegalArgumentException] thrownBy (delete from "toto").build()
+    }
+
+    it("deletes object empty objectID") {
+      the[IllegalArgumentException] thrownBy (delete from "toto" objectId "")
+    }
+
+    it("deletes object whitespaces objectID") {
+      the[IllegalArgumentException] thrownBy (delete from "toto" objectId "   ")
     }
 
     it("should call API") {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Need Doc update   | no


## Describe your change
`deleteObject` needs a non-empty/null objectID

## What problem is this fixing?
If the objectID is empty, the entire index will be deleted instead of one record.

