### PR TITLE
Insights & Perso

### DIFF
--- a/src/main/scala/algolia/AlgoliaClient.scala
+++ b/src/main/scala/algolia/AlgoliaClient.scala
@@ -82,6 +82,7 @@ class AlgoliaClient(applicationId: String,
       ))
 
   val analyticsHost: String = "https://analytics.algolia.com"
+  val insightsHost: String = "https://insights.algolia.io"
 
   val userAgent =
     s"Algolia for Scala (${BuildInfo.version}); JVM (${System.getProperty("java.version")}); Scala (${BuildInfo.scalaVersion})"
@@ -129,6 +130,8 @@ class AlgoliaClient(applicationId: String,
       implicit executor: ExecutionContext): Future[T] = {
     if (payload.isAnalytics) {
       requestAnalytics(payload)
+    } else if (payload.isInsights) {
+      requestInsights(payload)
     } else {
       requestSearch(payload)
     }
@@ -140,6 +143,15 @@ class AlgoliaClient(applicationId: String,
       case Failure(e) =>
         logger.debug("Analytics API call failed", e)
         Future.failed(new AlgoliaClientException("Analytics API call failed", e))
+    }
+  }
+
+  private[algolia] def requestInsights[T: Manifest](payload: HttpPayload)(
+      implicit executor: ExecutionContext): Future[T] = {
+    httpClient.request[T](insightsHost, headers, payload).andThen {
+      case Failure(e) =>
+        logger.debug("Insights API call failed", e)
+        Future.failed(new AlgoliaClientException("Insights API call failed", e))
     }
   }
 

--- a/src/main/scala/algolia/AlgoliaDsl.scala
+++ b/src/main/scala/algolia/AlgoliaDsl.scala
@@ -65,6 +65,7 @@ trait AlgoliaDsl
     with TaskStatusDsl
     with AssignDsl
     with RemoveDsl
+    with SendDsl
 
 object AlgoliaDsl extends AlgoliaDsl {
 

--- a/src/main/scala/algolia/AlgoliaDsl.scala
+++ b/src/main/scala/algolia/AlgoliaDsl.scala
@@ -66,6 +66,7 @@ trait AlgoliaDsl
     with AssignDsl
     with RemoveDsl
     with SendDsl
+    with SetDsl
 
 object AlgoliaDsl extends AlgoliaDsl {
 

--- a/src/main/scala/algolia/definitions/InsightsEventDefinition.scala
+++ b/src/main/scala/algolia/definitions/InsightsEventDefinition.scala
@@ -1,0 +1,32 @@
+package algolia.definitions
+
+import algolia.http.{HttpPayload, POST}
+import algolia.inputs.InsightsEvent
+import algolia.objects.RequestOptions
+import org.json4s.Formats
+import org.json4s.native.Serialization.write
+
+case class InsightsEventDefinition(
+    events: Iterable[InsightsEvent],
+    requestOptions: Option[RequestOptions] = None)(implicit val formats: Formats)
+    extends Definition {
+
+  override type T = InsightsEventDefinition
+
+  override def options(requestOptions: RequestOptions): InsightsEventDefinition =
+    copy(requestOptions = Some(requestOptions))
+
+  override private[algolia] def build(): HttpPayload = {
+    val body = Map("events" -> events)
+
+    HttpPayload(
+      POST,
+      Seq("1", "events"),
+      body = Some(write(body)),
+      isSearch = false,
+      isInsights = true,
+      requestOptions = requestOptions
+    )
+  }
+
+}

--- a/src/main/scala/algolia/definitions/StrategyDefinition.scala
+++ b/src/main/scala/algolia/definitions/StrategyDefinition.scala
@@ -1,0 +1,49 @@
+package algolia.definitions
+
+import algolia.http.{GET, HttpPayload, POST}
+import algolia.objects.Strategy
+import algolia.objects.RequestOptions
+import org.json4s.Formats
+import org.json4s.native.Serialization.write
+
+case class GetPersonalizationStrategyDefinition(requestOptions: Option[RequestOptions] = None)(
+    implicit val formats: Formats)
+    extends Definition {
+
+  override type T = GetPersonalizationStrategyDefinition
+
+  override def options(requestOptions: RequestOptions): GetPersonalizationStrategyDefinition =
+    copy(requestOptions = Some(requestOptions))
+
+  override private[algolia] def build(): HttpPayload = {
+    HttpPayload(
+      GET,
+      Seq("1", "recommendation", "personalization", "strategy"),
+      isSearch = true,
+      requestOptions = requestOptions
+    )
+  }
+
+}
+
+case class SetPersonalizationStrategyDefinition(
+    s: Strategy,
+    requestOptions: Option[RequestOptions] = None)(implicit val formats: Formats)
+    extends Definition {
+
+  override type T = SetPersonalizationStrategyDefinition
+
+  override def options(requestOptions: RequestOptions): SetPersonalizationStrategyDefinition =
+    copy(requestOptions = Some(requestOptions))
+
+  override private[algolia] def build(): HttpPayload = {
+    HttpPayload(
+      POST,
+      Seq("1", "recommendation", "personalization", "strategy"),
+      body = Some(write(s)),
+      isSearch = false,
+      requestOptions = requestOptions
+    )
+  }
+
+}

--- a/src/main/scala/algolia/dsl/GetDsl.scala
+++ b/src/main/scala/algolia/dsl/GetDsl.scala
@@ -27,6 +27,7 @@ package algolia.dsl
 
 import algolia.AlgoliaDsl.ABTests
 import algolia.definitions._
+import algolia.objects.Strategy
 import algolia.responses.{GetObject, Results, TopUserID, UserDataWithCluster}
 import algolia.{AlgoliaClient, Executable}
 import org.json4s.Formats
@@ -66,6 +67,9 @@ trait GetDsl {
 
     def userID(userID: String) = GetUserIDDefinition(userID)
 
+    // Personalization
+    def personalizationStrategy() = GetPersonalizationStrategyDefinition()
+
   }
 
   implicit object GetObjectDefinitionExecutable
@@ -100,6 +104,14 @@ trait GetDsl {
     override def apply(client: AlgoliaClient, query: GetUserIDDefinition)(
         implicit executor: ExecutionContext): Future[UserDataWithCluster] = {
       client.request[UserDataWithCluster](query.build())
+    }
+  }
+
+  implicit object GetPersonalizationStrategyExecutable
+      extends Executable[GetPersonalizationStrategyDefinition, Strategy] {
+    override def apply(client: AlgoliaClient, query: GetPersonalizationStrategyDefinition)(
+        implicit executor: ExecutionContext): Future[Strategy] = {
+      client.request[Strategy](query.build())
     }
   }
 

--- a/src/main/scala/algolia/dsl/SendDsl.scala
+++ b/src/main/scala/algolia/dsl/SendDsl.scala
@@ -1,0 +1,28 @@
+package algolia.dsl
+
+import algolia.{AlgoliaClient, Executable}
+import algolia.definitions.InsightsEventDefinition
+import algolia.inputs._
+import algolia.responses.InsightsEventResponse
+import org.json4s.Formats
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait SendDsl {
+  implicit val formats: Formats
+
+  case object send {
+
+    def event(e: InsightsEvent): InsightsEventDefinition = InsightsEventDefinition(Seq(e))
+    def events(e: Iterable[InsightsEvent]): InsightsEventDefinition = InsightsEventDefinition(e)
+
+  }
+
+  implicit object SendInsightEventExecutable
+      extends Executable[InsightsEventDefinition, InsightsEventResponse] {
+    override def apply(client: AlgoliaClient, query: InsightsEventDefinition)(
+        implicit executor: ExecutionContext): Future[InsightsEventResponse] = {
+      client.request[InsightsEventResponse](query.build())
+    }
+  }
+}

--- a/src/main/scala/algolia/dsl/SetDsl.scala
+++ b/src/main/scala/algolia/dsl/SetDsl.scala
@@ -1,0 +1,33 @@
+package algolia.dsl
+
+import algolia.{AlgoliaClient, Executable}
+import algolia.definitions.{
+  GetPersonalizationStrategyDefinition,
+  SetPersonalizationStrategyDefinition
+}
+import algolia.inputs._
+import algolia.objects.Strategy
+import algolia.responses.SetStrategyResult
+import org.json4s.Formats
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait SetDsl {
+  implicit val formats: Formats
+
+  case object set {
+
+    def personalizationStrategy(s: Strategy): SetPersonalizationStrategyDefinition =
+      SetPersonalizationStrategyDefinition(s)
+
+  }
+
+  implicit object SetPersonalizationStrategyExecutable
+      extends Executable[SetPersonalizationStrategyDefinition, SetStrategyResult] {
+    override def apply(client: AlgoliaClient, query: SetPersonalizationStrategyDefinition)(
+        implicit executor: ExecutionContext): Future[SetStrategyResult] = {
+      client.request[SetStrategyResult](query.build())
+    }
+  }
+
+}

--- a/src/main/scala/algolia/http/HttpPayload.scala
+++ b/src/main/scala/algolia/http/HttpPayload.scala
@@ -56,6 +56,7 @@ private[algolia] case class HttpPayload(verb: HttpVerb,
                                         body: Option[String] = None,
                                         isSearch: Boolean,
                                         isAnalytics: Boolean = false,
+                                        isInsights: Boolean = false,
                                         requestOptions: Option[RequestOptions]) {
 
   def apply(host: String,

--- a/src/main/scala/algolia/inputs/InsightsEvent.scala
+++ b/src/main/scala/algolia/inputs/InsightsEvent.scala
@@ -1,0 +1,73 @@
+package algolia.inputs
+
+case class InsightsEvent(
+    eventType: String,
+    eventName: String,
+    index: String,
+    userToken: String,
+    timestamp: Option[Long] = None, // Epoch timestamp in millisecond
+    objectIDs: Option[Iterable[String]] = None,
+    filters: Option[Iterable[String]] = None,
+    positions: Option[Iterable[Int]] = None,
+    queryID: Option[String] = None
+)
+
+object ClickedFilters {
+  def apply(userToken: String, eventName: String, indexName: String, filters: Iterable[String]) =
+    InsightsEvent("click", eventName, indexName, userToken, filters = Some(filters))
+}
+
+object ClickedObjectIDs {
+  def apply(userToken: String, eventName: String, indexName: String, objectIDs: Iterable[String]) =
+    InsightsEvent("click", eventName, indexName, userToken, objectIDs = Some(objectIDs))
+}
+
+object ClickedObjectIDsAfterSearch {
+  def apply(userToken: String,
+            eventName: String,
+            indexName: String,
+            objectIDs: Iterable[String],
+            positions: Iterable[Int],
+            queryID: String) =
+    InsightsEvent("click",
+                  eventName,
+                  indexName,
+                  userToken,
+                  objectIDs = Some(objectIDs),
+                  positions = Some(positions),
+                  queryID = Some(queryID))
+}
+
+object ConvertedObjectIDs {
+  def apply(userToken: String, eventName: String, indexName: String, objectIDs: Iterable[String]) =
+    InsightsEvent("conversion", eventName, indexName, userToken, objectIDs = Some(objectIDs))
+}
+
+object ConvertedObjectIDsAfterSearch {
+  def apply(userToken: String,
+            eventName: String,
+            indexName: String,
+            objectIDs: Iterable[String],
+            queryID: String) =
+    InsightsEvent("conversion",
+                  eventName,
+                  indexName,
+                  userToken,
+                  objectIDs = Some(objectIDs),
+                  queryID = Some(queryID))
+}
+
+object ConvertedFilters {
+  def apply(userToken: String, eventName: String, indexName: String, filters: Iterable[String]) =
+    InsightsEvent("conversion", eventName, indexName, userToken, filters = Some(filters))
+}
+
+object ViewedFilters {
+  def apply(userToken: String, eventName: String, indexName: String, filters: Iterable[String]) =
+    InsightsEvent("view", eventName, indexName, userToken, filters = Some(filters))
+}
+
+object ViewedObjectIDs {
+  def apply(userToken: String, eventName: String, indexName: String, objectIDs: Iterable[String]) =
+    InsightsEvent("view", eventName, indexName, userToken, objectIDs = Some(objectIDs))
+}

--- a/src/main/scala/algolia/objects/Query.scala
+++ b/src/main/scala/algolia/objects/Query.scala
@@ -107,6 +107,8 @@ case class Query(
                  restrictSources: Option[String] = None,
                  /* Browse */
                  cursor: Option[String] = None,
+                 /* Personalization */
+                 enablePersonalization: Option[Boolean] = None,
                  /* CUSTOM */
                  customParameters: Option[Map[String, String]] = None) {
 

--- a/src/main/scala/algolia/objects/Strategy.scala
+++ b/src/main/scala/algolia/objects/Strategy.scala
@@ -1,0 +1,8 @@
+package algolia.objects
+
+case class Strategy(eventsScoring: Option[Map[String, ScoreType]] = None,
+                    facetsScoring: Option[Map[String, Score]] = None)
+
+case class ScoreType(score: Int, `type`: String)
+
+case class Score(score: Int)

--- a/src/main/scala/algolia/responses/Insights.scala
+++ b/src/main/scala/algolia/responses/Insights.scala
@@ -1,0 +1,3 @@
+package algolia.responses
+
+case class InsightsEventResponse(status: Int, message: String)

--- a/src/main/scala/algolia/responses/Personalization.scala
+++ b/src/main/scala/algolia/responses/Personalization.scala
@@ -1,0 +1,3 @@
+package algolia.responses
+
+case class SetStrategyResult(updatedAt: String)

--- a/src/test/scala/algolia/dsl/SendTest.scala
+++ b/src/test/scala/algolia/dsl/SendTest.scala
@@ -1,0 +1,140 @@
+package algolia.dsl
+
+import algolia.AlgoliaDsl._
+import algolia.AlgoliaTest
+import algolia.http.{HttpPayload, POST}
+import algolia.inputs._
+
+class SendTest extends AlgoliaTest {
+
+  describe("send event payloads") {
+
+    it("should produce ClickedFilters payload") {
+      (send event ClickedFilters("user-token", "event-name", "index-name", Seq("filter")))
+        .build() should be(
+        HttpPayload(
+          POST,
+          Seq("1", "events"),
+          body = Some(
+            """{"events":[{"eventType":"click","eventName":"event-name","index":"index-name","userToken":"user-token","filters":["filter"]}]}"""),
+          isSearch = false,
+          isInsights = true,
+          requestOptions = None
+        )
+      )
+    }
+
+    it("should produce ClickedObjectIDs payload") {
+      (send event ClickedObjectIDs("user-token", "event-name", "index-name", Seq("objectID")))
+        .build() should be(
+        HttpPayload(
+          POST,
+          Seq("1", "events"),
+          body = Some(
+            """{"events":[{"eventType":"click","eventName":"event-name","index":"index-name","userToken":"user-token","objectIDs":["objectID"]}]}"""),
+          isSearch = false,
+          isInsights = true,
+          requestOptions = None
+        )
+      )
+    }
+
+    it("should produce ClickedObjectIDsAfterSearch payload") {
+      (send event ClickedObjectIDsAfterSearch("user-token",
+                                              "event-name",
+                                              "index-name",
+                                              Seq("objectID"),
+                                              Seq(42),
+                                              "query-id")).build() should be(
+        HttpPayload(
+          POST,
+          Seq("1", "events"),
+          body = Some(
+            """{"events":[{"eventType":"click","eventName":"event-name","index":"index-name","userToken":"user-token","objectIDs":["objectID"],"positions":[42],"queryID":"query-id"}]}"""),
+          isSearch = false,
+          isInsights = true,
+          requestOptions = None
+        )
+      )
+    }
+
+    it("should produce ConvertedObjectIDs payload") {
+      (send event ConvertedObjectIDs("user-token", "event-name", "index-name", Seq("objectID")))
+        .build() should be(
+        HttpPayload(
+          POST,
+          Seq("1", "events"),
+          body = Some(
+            """{"events":[{"eventType":"conversion","eventName":"event-name","index":"index-name","userToken":"user-token","objectIDs":["objectID"]}]}"""),
+          isSearch = false,
+          isInsights = true,
+          requestOptions = None
+        )
+      )
+    }
+
+    it("should produce ConvertedObjectIDsAfterSearch payload") {
+      (send event ConvertedObjectIDsAfterSearch("user-token",
+                                                "event-name",
+                                                "index-name",
+                                                Seq("objectID"),
+                                                "query-id")).build() should be(
+        HttpPayload(
+          POST,
+          Seq("1", "events"),
+          body = Some(
+            """{"events":[{"eventType":"conversion","eventName":"event-name","index":"index-name","userToken":"user-token","objectIDs":["objectID"],"queryID":"query-id"}]}"""),
+          isSearch = false,
+          isInsights = true,
+          requestOptions = None
+        )
+      )
+    }
+
+    it("should produce ConvertedFilters payload") {
+      (send event ConvertedFilters("user-token", "event-name", "index-name", Seq("filter")))
+        .build() should be(
+        HttpPayload(
+          POST,
+          Seq("1", "events"),
+          body = Some(
+            """{"events":[{"eventType":"conversion","eventName":"event-name","index":"index-name","userToken":"user-token","filters":["filter"]}]}"""),
+          isSearch = false,
+          isInsights = true,
+          requestOptions = None
+        )
+      )
+    }
+
+    it("should produce ViewedFilters payload") {
+      (send event ViewedFilters("user-token", "event-name", "index-name", Seq("filter")))
+        .build() should be(
+        HttpPayload(
+          POST,
+          Seq("1", "events"),
+          body = Some(
+            """{"events":[{"eventType":"view","eventName":"event-name","index":"index-name","userToken":"user-token","filters":["filter"]}]}"""),
+          isSearch = false,
+          isInsights = true,
+          requestOptions = None
+        )
+      )
+    }
+
+    it("should produce ViewedObjectIDs payload") {
+      (send event ViewedObjectIDs("user-token", "event-name", "index-name", Seq("objectID")))
+        .build() should be(
+        HttpPayload(
+          POST,
+          Seq("1", "events"),
+          body = Some(
+            """{"events":[{"eventType":"view","eventName":"event-name","index":"index-name","userToken":"user-token","objectIDs":["objectID"]}]}"""),
+          isSearch = false,
+          isInsights = true,
+          requestOptions = None
+        )
+      )
+    }
+
+  }
+}

--- a/src/test/scala/algolia/dsl/StrategyTest.scala
+++ b/src/test/scala/algolia/dsl/StrategyTest.scala
@@ -1,0 +1,64 @@
+package algolia.dsl
+
+import algolia.AlgoliaDsl._
+import algolia.AlgoliaTest
+import algolia.http.{GET, HttpPayload, POST}
+import algolia.objects.{Score, ScoreType, Strategy}
+
+import scala.language.postfixOps
+
+class StrategyTest extends AlgoliaTest {
+
+  describe("personalization strategy payloads") {
+
+    it("should produce empty set strategy payload") {
+      (set personalizationStrategy Strategy()).build() should be(
+        HttpPayload(
+          POST,
+          Seq("1", "recommendation", "personalization", "strategy"),
+          body = Some("{}"),
+          isSearch = false,
+          requestOptions = None
+        )
+      )
+    }
+
+    it("should produce non-empty set strategy payload") {
+      val strategy = Strategy(
+        eventsScoring = Some(
+          Map(
+            "event 1" -> ScoreType(10, "click"),
+            "event 2" -> ScoreType(20, "conversion")
+          )),
+        facetsScoring = Some(
+          Map(
+            "event 3" -> Score(30)
+          ))
+      )
+
+      (set personalizationStrategy strategy).build() should be(
+        HttpPayload(
+          POST,
+          Seq("1", "recommendation", "personalization", "strategy"),
+          body = Some(
+            """{"eventsScoring":{"event 1":{"score":10,"type":"click"},"event 2":{"score":20,"type":"conversion"}},"facetsScoring":{"event 3":{"score":30}}}"""),
+          isSearch = false,
+          requestOptions = None
+        )
+      )
+    }
+
+    it("should produce get strategy payload") {
+      (get personalizationStrategy).build() should be(
+        HttpPayload(
+          GET,
+          Seq("1", "recommendation", "personalization", "strategy"),
+          body = None,
+          isSearch = true,
+          requestOptions = None
+        )
+      )
+    }
+
+  }
+}


### PR DESCRIPTION
# Insights

```scala
client.execute {
  send event ClickedFilters("eventName", "indexName", []string{"filter"})
  send event ClickedObjectIDs("eventName", "indexName", []string{"objectID"})
  send event ClickedObjectIDsAfterSearch("eventName", "indexName", []string{"objectID"}, []string{42} /* positions */, "queryID")

  // Conversion events
  send event ConvertedObjectIDs("eventName", "indexName", []string{"objectID"})
  send event ConvertedObjectIDsAfterSearch("eventName", "indexName", []string{"objectID"}, "queryID")
  send event ConvertedFilters("eventName", "indexName", []string{"filter"})

  // View events
  send event ViewedFilters("eventName", "indexName", []string{"filter"})
  send event ViewedObjectIDs("eventName", "indexName", []string{"objectID"})

  // Send raw events
  send event InsightsEvent(...)
  send events Seq(InsightsEvent(...), ...)
}
```

# Personalization

```scala
client.execute {
  // Retrieve personalization strategy
  get strategy

  // Set personalization strategy
  set strategy Strategy(...)
}
```