### PR TITLE
Add missing Executable typeclass for SafeDeleteObjectDefinition

### DIFF
--- a/src/main/scala/algolia/dsl/DeleteDsl.scala
+++ b/src/main/scala/algolia/dsl/DeleteDsl.scala
@@ -86,4 +86,12 @@ trait DeleteDsl {
     }
   }
 
+  implicit object SafeDeleteObjectDefinitionExecutable
+    extends Executable[SafeDeleteObjectDefinition, Task] {
+    override def apply(client: AlgoliaClient, query: SafeDeleteObjectDefinition)(
+      implicit executor: ExecutionContext): Future[Task] = {
+      client.request[Task](query.build())
+    }
+  }
+
 }

--- a/src/main/scala/algolia/dsl/DeleteDsl.scala
+++ b/src/main/scala/algolia/dsl/DeleteDsl.scala
@@ -87,9 +87,9 @@ trait DeleteDsl {
   }
 
   implicit object SafeDeleteObjectDefinitionExecutable
-    extends Executable[SafeDeleteObjectDefinition, Task] {
+      extends Executable[SafeDeleteObjectDefinition, Task] {
     override def apply(client: AlgoliaClient, query: SafeDeleteObjectDefinition)(
-      implicit executor: ExecutionContext): Future[Task] = {
+        implicit executor: ExecutionContext): Future[Task] = {
       client.request[Task](query.build())
     }
   }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | n/a
| Need Doc update   | no


## Describe your change

The new 'delete objectFromIndex X' syntax introduced in #498 was missing a typeclass to execute the new SafeDeleteObjectDefinition. 

## What problem is this fixing?

The following code currently does not compile with `could not find implicit value for parameter executable: algolia.Executable[algolia.definitions.SafeDeleteObjectDefinition,RESULT]`:
```
val op: Option[SafeDeleteObjectOperation] = SafeDeleteObjectOperation("index", "objectID")
algoliaClient.execute(delete objectFromIndex op.get)
```
