### PR TITLE
fixed: Ensure that the DnsNameResolver is closed when the AlgoliaClient is

### DIFF
--- a/src/main/scala/algolia/AlgoliaHttpClient.scala
+++ b/src/main/scala/algolia/AlgoliaHttpClient.scala
@@ -62,7 +62,10 @@ case class AlgoliaHttpClient(
 
   implicit val formats: Formats = AlgoliaDsl.formats
 
-  def close(): Unit = _httpClient.close()
+  def close(): Unit = {
+    dnsNameResolver.close()
+    _httpClient.close()
+  }
 
   def request[T: Manifest](host: String, headers: Map[String, String], payload: HttpPayload)(
       implicit executor: ExecutionContext): Future[T] = {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #500
| Need Doc update   | no


## Describe your change

Make sure that `DnsNameResolver.close()` is called when the `AlgoliaClient.close()` is called.

## What problem is this fixing?

Problem is better described in #500 but essentially, prior to that fix, sockets were leaked and could lead to exhaustion when many `AlgoliaClient` got instantiated in the same JVM.

@Ant-hem @ElPicador If you guys could help me know how to run a single ScalaTest with specific JVM options, I'd be happy to know because I couldn't find an easy way of doing so to integrate the test suggested by @tanin47 in his issue. Thanks in advance for any help.