### PR TITLE
added: support new customSearchParameters field in ABTest variants for AA testing

### DIFF
--- a/src/main/scala/algolia/inputs/ABTest.scala
+++ b/src/main/scala/algolia/inputs/ABTest.scala
@@ -27,6 +27,11 @@ package algolia.inputs
 
 import java.time.LocalDateTime
 
+import algolia.objects.Query
+
 case class ABTest(name: String, variants: Seq[ABTestVariant], endAt: LocalDateTime)
 
-case class ABTestVariant(index: String, trafficPercentage: Int, description: Option[String] = None)
+case class ABTestVariant(index: String,
+                         trafficPercentage: Int,
+                         description: Option[String] = None,
+                         customSearchParameters: Option[Query] = None)

--- a/src/main/scala/algolia/responses/ABTest.scala
+++ b/src/main/scala/algolia/responses/ABTest.scala
@@ -27,6 +27,8 @@ package algolia.responses
 
 import java.time.LocalDateTime
 
+import algolia.objects.Query
+
 case class ABTestsResponse(abtests: Seq[ABTestResponse], count: Int, total: Int)
 
 case class ABTestResponse(abTestID: Int,
@@ -48,4 +50,5 @@ case class VariantResponse(averageClickPosition: Option[Int],
                            noResultCount: Option[Int],
                            searchCount: Option[Int],
                            trafficPercentage: Int,
-                           userCount: Option[Int])
+                           userCount: Option[Int],
+                           customSearchParameters: Option[Query])

--- a/src/test/scala/algolia/integration/SearchIntegrationTest.scala
+++ b/src/test/scala/algolia/integration/SearchIntegrationTest.scala
@@ -101,7 +101,9 @@ class SearchIntegrationTest extends AlgoliaTest {
               "name" -> HighlightResult("<em>a</em>lgolia",
                                         "full",
                                         Seq("a"),
-                                        fullyHighlighted = Some(false)))),
+                                        fullyHighlighted = Some(false)),
+              "age" -> HighlightResult("10", "none", Seq.empty, fullyHighlighted = None)
+            )),
           None,
           None,
           None


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | 
| Need Doc update   | no


## Describe your change

Implement the new `customSearchParameters` field in ABTest variants to let users deploy AA tests.