### PR TITLE
Update asyncHttpClientVersion from 2.6.0 to 2.8.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ scalaVersion := "2.12.2"
 
 coverageEnabled := false
 
-val asyncHttpClientVersion = "2.6.0"
+val asyncHttpClientVersion = "2.8.1"
 val json4sVersion = "3.5.2"
 val slf4jVersion = "1.7.25"
 val scalaUriVersion = "0.4.16"


### PR DESCRIPTION
This version contains the fix for the DNS Resolution bug found in netty.
https://github.com/netty/netty/issues/8261

| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix https://github.com/netty/netty/issues/8261
| Need Doc update   | no


## Describe your change

Updated async-http-client which contains fix for bug found in https://github.com/netty/netty/issues/8261

## What problem is this fixing?

Problem described here in the netty bug.
