### PR TITLE
fix: Partial update objects no create

### DIFF
--- a/src/main/scala/algolia/definitions/BatchDefinition.scala
+++ b/src/main/scala/algolia/definitions/BatchDefinition.scala
@@ -98,7 +98,7 @@ case class BatchDefinition(
                                                   _) =>
         val body = Map(
           "objectID" -> objectId,
-          attribute -> PartialUpdateObject(operation.name, value)
+          attribute -> PartialUpdateObjectNoCreate(operation.name, value)
         )
         Traversable(PartialUpdateObjectNoCreateOperation(Extraction.decompose(body), index))
 

--- a/src/main/scala/algolia/inputs/PartialUpdateObjectNoCreate.scala
+++ b/src/main/scala/algolia/inputs/PartialUpdateObjectNoCreate.scala
@@ -1,0 +1,28 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Algolia
+ * http://www.algolia.com/
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package algolia.inputs
+
+case class PartialUpdateObjectNoCreate(_operation: String, value: Option[Any])

--- a/src/test/scala/algolia/dsl/PartialUpdateObjectTest.scala
+++ b/src/test/scala/algolia/dsl/PartialUpdateObjectTest.scala
@@ -221,6 +221,25 @@ class PartialUpdateObjectTest extends AlgoliaTest {
         )
       )
     }
+    
+    it("should do not create if not exist") {
+      partialUpdate from "index" createIfNotExists false objects Seq(BasicObjectWithObjectID("name1", 1, "myId"))
+    }
+
+    it("should call API") {
+      (partialUpdate from "index" createIfNotExists false objects Seq(BasicObjectWithObjectID("name1", 1, "myId")))
+        .build() should be(
+        HttpPayload(
+          POST,
+          Seq("1", "indexes", "*", "batch"),
+          queryParameters = None,
+          body = Some(
+            """{"requests":[{"body":{"name":"name1","age":1,"objectID":"myId"},"indexName":"index","action":"partialUpdateObjectNoCreate"}]}"""),
+          isSearch = false,
+          requestOptions = None
+        )
+      )
+    }
 
   }
 


### PR DESCRIPTION

| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no   
| BC breaks?        | no     
| Need Doc update   | maybe? this case is not in the docs


## Describe your change

The `createIfNotExists false` parameter is lost in translation when
building the http request for a batched partialUpdate. From what I can see [in the rest api
doc](https://www.algolia.com/doc/rest-api/search/#operations-you-can-batch),
the batch elements should be of type `partialUpdateObjectNoCreate`.

I added the relevant classes and some tests, but without some
credentials I cannot run the tests locally.

## What problem is this fixing?

The http request for a batched partialUpdateObject does not respect the createIfNotExists false parameter
