### PR TITLE
Fix partial objects no create in batch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,21 @@
 language: scala
 scala:
-- 2.11.11
-- 2.12.2
+  - 2.11.11
+  - 2.12.2
 
 jdk:
-  - oraclejdk8
+  - openjdk8
+
+before_cache:
+  # Cleanup the cached directories to avoid unnecessary cache updates
+  - rm -fv $HOME/.ivy2/.sbt.ivy.lock
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
+  - find $HOME/.sbt        -name "*.lock"               -print -delete
+
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt/boot/
 
 before_script:
   - "sbt ++$TRAVIS_SCALA_VERSION scalafmtTest"

--- a/src/main/scala/algolia/definitions/BatchDefinition.scala
+++ b/src/main/scala/algolia/definitions/BatchDefinition.scala
@@ -112,8 +112,12 @@ case class BatchDefinition(
       case IndexingBatchDefinition(_, defs, _) =>
         defs.flatMap(transform)
 
-      case PartialUpdateOneObjectDefinition(index, Some(obj), _, _) =>
-        Traversable(PartialUpdateObjectOperation(Extraction.decompose(obj), Some(index)))
+      case PartialUpdateOneObjectDefinition(index, Some(obj), createIfNotExists, _) =>
+        if (createIfNotExists) {
+          Traversable(PartialUpdateObjectOperation(Extraction.decompose(obj), Some(index)))
+        } else {
+          Traversable(PartialUpdateObjectNoCreateOperation(Extraction.decompose(obj), Some(index)))
+        }
     }
   }
 }

--- a/src/test/scala/algolia/dsl/PartialUpdateObjectTest.scala
+++ b/src/test/scala/algolia/dsl/PartialUpdateObjectTest.scala
@@ -27,6 +27,7 @@ package algolia.dsl
 
 import algolia.AlgoliaDsl._
 import algolia.AlgoliaTest
+import algolia.definitions.BatchDefinition
 import algolia.http.{HttpPayload, POST}
 
 class PartialUpdateObjectTest extends AlgoliaTest {
@@ -182,7 +183,51 @@ class PartialUpdateObjectTest extends AlgoliaTest {
   describe("partial update") {
 
     it("should partial update") {
+      partialUpdate from "index" `object` BasicObjectWithObjectID("name1", 1, "myId")
+    }
+
+    it("should call API") {
+      (partialUpdate from "index" `object` BasicObjectWithObjectID("name1", 1, "myId"))
+        .build() should be(
+        HttpPayload(
+          POST,
+          Seq("1", "indexes", "index", "myId", "partial"),
+          queryParameters = None,
+          body = Some("""{"name":"name1","age":1,"objectID":"myId"}"""),
+          isSearch = false,
+          requestOptions = None
+        )
+      )
+    }
+
+  }
+
+  describe("partial update create") {
+
+    it("should partial update") {
       partialUpdate from "index" `object` BasicObjectWithObjectID("name1", 1, "myId") createIfNotExists true
+    }
+
+    it("should call API") {
+      (partialUpdate from "index" `object` BasicObjectWithObjectID("name1", 1, "myId") createIfNotExists true)
+        .build() should be(
+        HttpPayload(
+          POST,
+          Seq("1", "indexes", "index", "myId", "partial"),
+          queryParameters = None,
+          body = Some("""{"name":"name1","age":1,"objectID":"myId"}"""),
+          isSearch = false,
+          requestOptions = None
+        )
+      )
+    }
+
+  }
+
+  describe("partial update no create") {
+
+    it("should partial update") {
+      partialUpdate from "index" `object` BasicObjectWithObjectID("name1", 1, "myId") createIfNotExists false
     }
 
     it("should call API") {
@@ -216,6 +261,56 @@ class PartialUpdateObjectTest extends AlgoliaTest {
           queryParameters = None,
           body = Some(
             """{"requests":[{"body":{"name":"name1","age":1,"objectID":"myId"},"indexName":"index","action":"partialUpdateObject"}]}"""),
+          isSearch = false,
+          requestOptions = None
+        )
+      )
+    }
+
+  }
+
+  describe("partial update objects create") {
+
+    it("should partial update") {
+      partialUpdate from "index" createIfNotExists true objects Seq(
+        BasicObjectWithObjectID("name1", 1, "myId"))
+    }
+
+    it("should call API") {
+      (partialUpdate from "index" createIfNotExists true objects Seq(
+        BasicObjectWithObjectID("name1", 1, "myId")))
+        .build() should be(
+        HttpPayload(
+          POST,
+          Seq("1", "indexes", "*", "batch"),
+          queryParameters = None,
+          body = Some(
+            """{"requests":[{"body":{"name":"name1","age":1,"objectID":"myId"},"indexName":"index","action":"partialUpdateObject"}]}"""),
+          isSearch = false,
+          requestOptions = None
+        )
+      )
+    }
+
+  }
+
+  describe("partial update objects no create") {
+
+    it("should partial update") {
+      partialUpdate from "index" createIfNotExists false objects Seq(
+        BasicObjectWithObjectID("name1", 1, "myId"))
+    }
+
+    it("should call API") {
+      (partialUpdate from "index" createIfNotExists false objects Seq(
+        BasicObjectWithObjectID("name1", 1, "myId")))
+        .build() should be(
+        HttpPayload(
+          POST,
+          Seq("1", "indexes", "*", "batch"),
+          queryParameters = None,
+          body = Some(
+            """{"requests":[{"body":{"name":"name1","age":1,"objectID":"myId"},"indexName":"index","action":"partialUpdateObjectNoCreate"}]}"""),
           isSearch = false,
           requestOptions = None
         )


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #544 
| Need Doc update   | no


## Describe your change

`createIfNotExists false` was ignored when generating batch of `partialUpdate` operations. This was reported by @jtanguy in https://github.com/algolia/algoliasearch-client-scala/pull/544 at first but the some tests were missing to handle all use-cases and the proposed solution was not fixing the issue.

## What problem is this fixing?

By avoiding to ignore the `createIfNotExists` field of `PartialUpdateOneObjectDefinition` in `BatchDefinition.transform`, we can now generate the proper payload according to the boolean value.