### PR TITLE
adds: indexLanguages settings properties

### DIFF
--- a/src/main/scala/algolia/objects/IndexSettings.scala
+++ b/src/main/scala/algolia/objects/IndexSettings.scala
@@ -34,6 +34,7 @@ case class IndexSettings(
     minProximity: Option[Int] = None,
     keepDiacriticsOnCharacters: Option[String] = None,
     queryLanguages: Option[Seq[String]] = None,
+    indexLanguages: Option[Seq[String]] = None,
     attributeCriteriaComputedByMinProximity: Option[Boolean] = None,
     primary: Option[String] = None,
     userData: Option[Any] = None,


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | Fix #541 
| Need Doc update   | yes


## Describe your change

Implement the new `indexLanguages` setting which is an array of strings.
Currently, only `["ja"]` is supported by the engine.