### PR TITLE
feat(queryRules/alternatives)

### DIFF
--- a/src/main/scala/algolia/AlgoliaDsl.scala
+++ b/src/main/scala/algolia/AlgoliaDsl.scala
@@ -87,7 +87,8 @@ object AlgoliaDsl extends AlgoliaDsl {
       new RemoveStopWordsSerializer +
       new IgnorePluralsSerializer +
       new LocalDateTimeSerializer +
-      new ZonedDateTimeSerializer
+      new ZonedDateTimeSerializer +
+      new AlternativesSerializer
 
   val searchableAttributesUnordered: Regex = """^unordered\(([\w-]+)\)$""".r
   val searchableAttributesAttributes: Regex =
@@ -314,6 +315,16 @@ object AlgoliaDsl extends AlgoliaDsl {
           case RemoveStopWords.`true` => JBool(true)
           case RemoveStopWords.`false` => JBool(false)
           case RemoveStopWords.list(i) => JString(i.mkString(","))
+        }))
+
+  class AlternativesSerializer
+      extends CustomSerializer[Alternatives](_ =>
+        ({
+          case JBool(true) => Alternatives.`true`
+          case JBool(false) => Alternatives.`false`
+        }, {
+          case Alternatives.`true` => JBool(true)
+          case Alternatives.`false` => JBool(false)
         }))
 
   class IgnorePluralsSerializer

--- a/src/main/scala/algolia/objects/Alternatives.scala
+++ b/src/main/scala/algolia/objects/Alternatives.scala
@@ -25,23 +25,18 @@
 
 package algolia.objects
 
-case class Rule(objectID: String,
-                enabled: Option[Boolean] = None,
-                condition: Condition,
-                consequence: Consequence,
-                validity: Option[Iterable[TimeRange]] = None,
-                description: Option[String] = None)
+trait Alternatives {
 
-case class Condition(pattern: String,
-                     anchoring: String,
-                     context: Option[String] = None,
-                     alternatives: Option[Alternatives] = None)
+  val value: Any
 
-case class Consequence(params: Option[Map[String, Any]] = None,
-                       promote: Option[Iterable[ConsequencePromote]] = None,
-                       hide: Option[Iterable[ConsequenceHide]] = None,
-                       userData: Option[Map[String, Any]] = None)
+}
 
-case class ConsequencePromote(objectID: String, position: Int)
+object Alternatives {
+  case object `true` extends Alternatives {
+    override val value = true
+  }
 
-case class ConsequenceHide(objectID: String)
+  case object `false` extends Alternatives {
+    override val value = false
+  }
+}

--- a/src/test/scala/algolia/integration/RulesIntegrationTest.scala
+++ b/src/test/scala/algolia/integration/RulesIntegrationTest.scala
@@ -219,7 +219,8 @@ class RulesIntegrationTest extends AlgoliaTest {
         validity = Some(Seq(TimeRange(from, until))),
         condition = Condition(
           pattern = "a",
-          anchoring = "is"
+          anchoring = "is",
+          alternatives = Some(Alternatives.`true`)
         ),
         consequence = Consequence(
           params = Some(Map("query" -> "1")),


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | Fix #542  
| Need Doc update   | yes

## Changes

This PR adds the`Alternatives` parameter in QueryRules conditions

Alternatives may transform into JSON object in the future.