### PR TITLE
Add support for Scala 2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: scala
 scala:
-  - 2.11.11
-  - 2.12.2
+  - 2.11.12
+  - 2.12.10
+  - 2.13.1
 
 jdk:
   - openjdk8

--- a/build.sbt
+++ b/build.sbt
@@ -6,21 +6,21 @@ description := "Scala client for Algolia Search API"
 
 version := "1.34.0"
 
-crossScalaVersions := Seq("2.11.11", "2.12.2")
+crossScalaVersions := Seq("2.11.12", "2.12.10", "2.13.1")
 
-scalaVersion := "2.12.2"
+scalaVersion := "2.13.1"
 
 coverageEnabled := false
 
 val asyncHttpClientVersion = "2.10.1"
-val json4sVersion = "3.5.2"
+val json4sVersion = "3.6.7"
 val slf4jVersion = "1.7.25"
-val scalaUriVersion = "0.4.16"
+val scalaUriVersion = "1.4.10"
 
 val logbackVersion = "1.2.3"
 val scalaTestVersion = "3.0.8"
-val scalaMockVersion = "3.4.2"
-val scalacheckVersion = "1.12.6"
+val scalaMockVersion = "4.4.0"
+val scalacheckVersion = "1.14.2"
 
 libraryDependencies += "org.asynchttpclient" % "async-http-client" % asyncHttpClientVersion
 
@@ -35,20 +35,18 @@ libraryDependencies += "io.lemonlabs" %% "scala-uri" % scalaUriVersion
 //Testing
 libraryDependencies += "org.scalatest" %% "scalatest" % scalaTestVersion % "test"
 libraryDependencies += "org.scalacheck" %% "scalacheck" % scalacheckVersion % "test"
-libraryDependencies += "org.scalamock" %% "scalamock-scalatest-support" % scalaMockVersion % "test"
+libraryDependencies += "org.scalamock" %% "scalamock" % scalaMockVersion % "test"
 libraryDependencies += "ch.qos.logback" % "logback-classic" % logbackVersion % "test"
 
 scalacOptions ++= Seq(
   "-deprecation",
-  "-Xfatal-warnings",
+  // "-Xfatal-warnings",
   "-feature", //Emit warning and location for usages of features that should be imported explicitly.
   "-encoding",
   "UTF-8",
   "-unchecked", //Enable additional warnings where generated code depends on assumptions
-  "-Yno-adapted-args",
   "-Ywarn-dead-code",
-  "-Ywarn-numeric-widen",
-  "-Xfuture"
+  "-Ywarn-numeric-widen"
 )
 
 /**

--- a/build.sbt
+++ b/build.sbt
@@ -33,10 +33,10 @@ libraryDependencies += "org.slf4j" % "slf4j-api" % slf4jVersion
 libraryDependencies += "io.lemonlabs" %% "scala-uri" % scalaUriVersion
 
 //Testing
-libraryDependencies += "org.scalatest" %% "scalatest" % scalaTestVersion % "test"
-libraryDependencies += "org.scalacheck" %% "scalacheck" % scalacheckVersion % "test"
-libraryDependencies += "org.scalamock" %% "scalamock" % scalaMockVersion % "test"
-libraryDependencies += "ch.qos.logback" % "logback-classic" % logbackVersion % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % scalaTestVersion % Test
+libraryDependencies += "org.scalacheck" %% "scalacheck" % scalacheckVersion % Test
+libraryDependencies += "org.scalamock" %% "scalamock" % scalaMockVersion % Test
+libraryDependencies += "ch.qos.logback" % "logback-classic" % logbackVersion % Test
 
 scalacOptions ++= Seq(
   "-deprecation",

--- a/src/main/scala/algolia/AlgoliaDsl.scala
+++ b/src/main/scala/algolia/AlgoliaDsl.scala
@@ -116,7 +116,7 @@ object AlgoliaDsl extends AlgoliaDsl {
           case JString(searchableAttributesUnordered(attr)) =>
             AttributesToIndex.unordered(attr)
           case JString(searchableAttributesAttributes(attrs)) =>
-            AttributesToIndex.attributes(attrs.split(","): _*)
+            AttributesToIndex.attributes(attrs.split(",").toIndexedSeq: _*)
           case JString(attr) => AttributesToIndex.attribute(attr)
         }, {
           case AttributesToIndex.unordered(attr) =>
@@ -132,7 +132,7 @@ object AlgoliaDsl extends AlgoliaDsl {
           case JString(searchableAttributesUnordered(attr)) =>
             SearchableAttributes.unordered(attr)
           case JString(searchableAttributesAttributes(attrs)) =>
-            SearchableAttributes.attributes(attrs.split(","): _*)
+            SearchableAttributes.attributes(attrs.split(",").toIndexedSeq: _*)
           case JString(attr) => SearchableAttributes.attribute(attr)
         }, {
           case SearchableAttributes.unordered(attr) =>
@@ -310,7 +310,7 @@ object AlgoliaDsl extends AlgoliaDsl {
         ({
           case JBool(true)   => RemoveStopWords.`true`
           case JBool(false)  => RemoveStopWords.`false`
-          case JString(list) => RemoveStopWords.list(list.split(","))
+          case JString(list) => RemoveStopWords.list(list.split(",").toSeq)
         }, {
           case RemoveStopWords.`true`  => JBool(true)
           case RemoveStopWords.`false` => JBool(false)
@@ -332,7 +332,7 @@ object AlgoliaDsl extends AlgoliaDsl {
         ({
           case JBool(true)   => IgnorePlurals.`true`
           case JBool(false)  => IgnorePlurals.`false`
-          case JString(list) => IgnorePlurals.list(list.split(","))
+          case JString(list) => IgnorePlurals.list(list.split(",").toSeq)
         }, {
           case IgnorePlurals.`true`  => JBool(true)
           case IgnorePlurals.`false` => JBool(false)

--- a/src/main/scala/algolia/AlgoliaDsl.scala
+++ b/src/main/scala/algolia/AlgoliaDsl.scala
@@ -122,7 +122,7 @@ object AlgoliaDsl extends AlgoliaDsl {
           case AttributesToIndex.unordered(attr) =>
             JString(s"unordered($attr)")
           case AttributesToIndex.attribute(attr) => JString(attr)
-          case AttributesToIndex.attributes(attributes @ _ *) =>
+          case AttributesToIndex.attributes(attributes @ _*) =>
             JString(attributes.mkString(","))
         }))
 
@@ -138,7 +138,7 @@ object AlgoliaDsl extends AlgoliaDsl {
           case SearchableAttributes.unordered(attr) =>
             JString(s"unordered($attr)")
           case SearchableAttributes.attribute(attr) => JString(attr)
-          case SearchableAttributes.attributes(attributes @ _ *) =>
+          case SearchableAttributes.attributes(attributes @ _*) =>
             JString(attributes.mkString(","))
         }))
 
@@ -155,47 +155,47 @@ object AlgoliaDsl extends AlgoliaDsl {
   class RankingSerializer
       extends CustomSerializer[Ranking](_ =>
         ({
-          case JString(asc(attr)) => Ranking.asc(attr)
-          case JString(desc(attr)) => Ranking.desc(attr)
-          case JString("typo") => Ranking.typo
-          case JString("geo") => Ranking.geo
-          case JString("words") => Ranking.words
+          case JString(asc(attr))   => Ranking.asc(attr)
+          case JString(desc(attr))  => Ranking.desc(attr)
+          case JString("typo")      => Ranking.typo
+          case JString("geo")       => Ranking.geo
+          case JString("words")     => Ranking.words
           case JString("proximity") => Ranking.proximity
           case JString("attribute") => Ranking.attribute
-          case JString("exact") => Ranking.exact
-          case JString("custom") => Ranking.custom
-          case JString("filters") => Ranking.filters
+          case JString("exact")     => Ranking.exact
+          case JString("custom")    => Ranking.custom
+          case JString("filters")   => Ranking.filters
         }, {
-          case Ranking.asc(attribute) => JString(s"asc($attribute)")
+          case Ranking.asc(attribute)  => JString(s"asc($attribute)")
           case Ranking.desc(attribute) => JString(s"desc($attribute)")
-          case Ranking.typo => JString("typo")
-          case Ranking.geo => JString("geo")
-          case Ranking.words => JString("words")
-          case Ranking.proximity => JString("proximity")
-          case Ranking.attribute => JString("attribute")
-          case Ranking.exact => JString("exact")
-          case Ranking.custom => JString("custom")
-          case Ranking.filters => JString("filters")
+          case Ranking.typo            => JString("typo")
+          case Ranking.geo             => JString("geo")
+          case Ranking.words           => JString("words")
+          case Ranking.proximity       => JString("proximity")
+          case Ranking.attribute       => JString("attribute")
+          case Ranking.exact           => JString("exact")
+          case Ranking.custom          => JString("custom")
+          case Ranking.filters         => JString("filters")
         }))
 
   class CustomRankingSerializer
       extends CustomSerializer[CustomRanking](_ =>
         ({
-          case JString(asc(attr)) => CustomRanking.asc(attr)
+          case JString(asc(attr))  => CustomRanking.asc(attr)
           case JString(desc(attr)) => CustomRanking.desc(attr)
         }, {
-          case CustomRanking.asc(attribute) => JString(s"asc($attribute)")
+          case CustomRanking.asc(attribute)  => JString(s"asc($attribute)")
           case CustomRanking.desc(attribute) => JString(s"desc($attribute)")
         }))
 
   class QueryTypeSerializer
       extends CustomSerializer[QueryType](_ =>
         ({
-          case JString("prefixAll") => QueryType.prefixAll
+          case JString("prefixAll")  => QueryType.prefixAll
           case JString("prefixLast") => QueryType.prefixLast
           case JString("prefixNone") => QueryType.prefixNone
         }, {
-          case QueryType.prefixAll => JString("prefixAll")
+          case QueryType.prefixAll  => JString("prefixAll")
           case QueryType.prefixLast => JString("prefixLast")
           case QueryType.prefixNone => JString("prefixNone")
         }))
@@ -203,39 +203,39 @@ object AlgoliaDsl extends AlgoliaDsl {
   class TypoToleranceSerializer
       extends CustomSerializer[TypoTolerance](_ =>
         ({
-          case JString("true") => TypoTolerance.`true`
-          case JString("false") => TypoTolerance.`false`
-          case JString("min") => TypoTolerance.min
+          case JString("true")   => TypoTolerance.`true`
+          case JString("false")  => TypoTolerance.`false`
+          case JString("min")    => TypoTolerance.min
           case JString("strict") => TypoTolerance.strict
         }, {
-          case TypoTolerance.`true` => JString("true")
+          case TypoTolerance.`true`  => JString("true")
           case TypoTolerance.`false` => JString("false")
-          case TypoTolerance.min => JString("min")
-          case TypoTolerance.strict => JString("strict")
+          case TypoTolerance.min     => JString("min")
+          case TypoTolerance.strict  => JString("strict")
         }))
 
   class AclSerializer
       extends CustomSerializer[Acl](_ =>
         ({
-          case JString("search") => Acl.search
-          case JString("browse") => Acl.browse
-          case JString("addObject") => Acl.addObject
+          case JString("search")       => Acl.search
+          case JString("browse")       => Acl.browse
+          case JString("addObject")    => Acl.addObject
           case JString("deleteObject") => Acl.deleteObject
-          case JString("deleteIndex") => Acl.deleteIndex
-          case JString("settings") => Acl.settings
+          case JString("deleteIndex")  => Acl.deleteIndex
+          case JString("settings")     => Acl.settings
           case JString("editSettings") => Acl.editSettings
-          case JString("analytics") => Acl.analytics
-          case JString("listIndexes") => Acl.listIndexes
+          case JString("analytics")    => Acl.analytics
+          case JString("listIndexes")  => Acl.listIndexes
         }, {
-          case Acl.search => JString("search")
-          case Acl.browse => JString("browse")
-          case Acl.addObject => JString("addObject")
+          case Acl.search       => JString("search")
+          case Acl.browse       => JString("browse")
+          case Acl.addObject    => JString("addObject")
           case Acl.deleteObject => JString("deleteObject")
-          case Acl.deleteIndex => JString("deleteIndex")
-          case Acl.settings => JString("settings")
+          case Acl.deleteIndex  => JString("deleteIndex")
+          case Acl.settings     => JString("settings")
           case Acl.editSettings => JString("editSettings")
-          case Acl.analytics => JString("analytics")
-          case Acl.listIndexes => JString("listIndexes")
+          case Acl.analytics    => JString("analytics")
+          case Acl.listIndexes  => JString("listIndexes")
         }))
 
   class QuerySynonymsSerializer
@@ -296,23 +296,23 @@ object AlgoliaDsl extends AlgoliaDsl {
   class DistinctSerializer
       extends CustomSerializer[Distinct](_ =>
         ({
-          case JBool(true) => Distinct.`true`
+          case JBool(true)  => Distinct.`true`
           case JBool(false) => Distinct.`false`
-          case JInt(i) => Distinct.int(i.toInt)
+          case JInt(i)      => Distinct.int(i.toInt)
         }, {
-          case Distinct.`true` => JBool(true)
+          case Distinct.`true`  => JBool(true)
           case Distinct.`false` => JBool(false)
-          case Distinct.int(i) => JInt(i)
+          case Distinct.int(i)  => JInt(i)
         }))
 
   class RemoveStopWordsSerializer
       extends CustomSerializer[RemoveStopWords](_ =>
         ({
-          case JBool(true) => RemoveStopWords.`true`
-          case JBool(false) => RemoveStopWords.`false`
+          case JBool(true)   => RemoveStopWords.`true`
+          case JBool(false)  => RemoveStopWords.`false`
           case JString(list) => RemoveStopWords.list(list.split(","))
         }, {
-          case RemoveStopWords.`true` => JBool(true)
+          case RemoveStopWords.`true`  => JBool(true)
           case RemoveStopWords.`false` => JBool(false)
           case RemoveStopWords.list(i) => JString(i.mkString(","))
         }))
@@ -320,21 +320,21 @@ object AlgoliaDsl extends AlgoliaDsl {
   class AlternativesSerializer
       extends CustomSerializer[Alternatives](_ =>
         ({
-          case JBool(true) => Alternatives.`true`
+          case JBool(true)  => Alternatives.`true`
           case JBool(false) => Alternatives.`false`
         }, {
-          case Alternatives.`true` => JBool(true)
+          case Alternatives.`true`  => JBool(true)
           case Alternatives.`false` => JBool(false)
         }))
 
   class IgnorePluralsSerializer
       extends CustomSerializer[IgnorePlurals](_ =>
         ({
-          case JBool(true) => IgnorePlurals.`true`
-          case JBool(false) => IgnorePlurals.`false`
+          case JBool(true)   => IgnorePlurals.`true`
+          case JBool(false)  => IgnorePlurals.`false`
           case JString(list) => IgnorePlurals.list(list.split(","))
         }, {
-          case IgnorePlurals.`true` => JBool(true)
+          case IgnorePlurals.`true`  => JBool(true)
           case IgnorePlurals.`false` => JBool(false)
           case IgnorePlurals.list(i) => JString(i.mkString(","))
         }))
@@ -358,9 +358,9 @@ object AlgoliaDsl extends AlgoliaDsl {
       extends CustomSerializer[ZonedDateTime](_ =>
         ({
           case JInt(l) =>
-            ZonedDateTime.ofInstant(Instant.ofEpochSecond(l.longValue()), ZoneOffset.UTC)
+            ZonedDateTime.ofInstant(Instant.ofEpochSecond(l.longValue), ZoneOffset.UTC)
         }, {
-          case ts: ZonedDateTime => JInt(ts.toEpochSecond())
+          case ts: ZonedDateTime => JInt(BigInt(ts.toEpochSecond))
         }))
 
   case object forwardToSlaves extends ForwardToReplicas

--- a/src/main/scala/algolia/AlgoliaDsl.scala
+++ b/src/main/scala/algolia/AlgoliaDsl.scala
@@ -122,7 +122,7 @@ object AlgoliaDsl extends AlgoliaDsl {
           case AttributesToIndex.unordered(attr) =>
             JString(s"unordered($attr)")
           case AttributesToIndex.attribute(attr) => JString(attr)
-          case AttributesToIndex.attributes(attributes @ _*) =>
+          case AttributesToIndex.attributes(attributes @ _ *) =>
             JString(attributes.mkString(","))
         }))
 
@@ -138,7 +138,7 @@ object AlgoliaDsl extends AlgoliaDsl {
           case SearchableAttributes.unordered(attr) =>
             JString(s"unordered($attr)")
           case SearchableAttributes.attribute(attr) => JString(attr)
-          case SearchableAttributes.attributes(attributes @ _*) =>
+          case SearchableAttributes.attributes(attributes @ _ *) =>
             JString(attributes.mkString(","))
         }))
 
@@ -155,47 +155,47 @@ object AlgoliaDsl extends AlgoliaDsl {
   class RankingSerializer
       extends CustomSerializer[Ranking](_ =>
         ({
-          case JString(asc(attr))   => Ranking.asc(attr)
-          case JString(desc(attr))  => Ranking.desc(attr)
-          case JString("typo")      => Ranking.typo
-          case JString("geo")       => Ranking.geo
-          case JString("words")     => Ranking.words
+          case JString(asc(attr)) => Ranking.asc(attr)
+          case JString(desc(attr)) => Ranking.desc(attr)
+          case JString("typo") => Ranking.typo
+          case JString("geo") => Ranking.geo
+          case JString("words") => Ranking.words
           case JString("proximity") => Ranking.proximity
           case JString("attribute") => Ranking.attribute
-          case JString("exact")     => Ranking.exact
-          case JString("custom")    => Ranking.custom
-          case JString("filters")   => Ranking.filters
+          case JString("exact") => Ranking.exact
+          case JString("custom") => Ranking.custom
+          case JString("filters") => Ranking.filters
         }, {
-          case Ranking.asc(attribute)  => JString(s"asc($attribute)")
+          case Ranking.asc(attribute) => JString(s"asc($attribute)")
           case Ranking.desc(attribute) => JString(s"desc($attribute)")
-          case Ranking.typo            => JString("typo")
-          case Ranking.geo             => JString("geo")
-          case Ranking.words           => JString("words")
-          case Ranking.proximity       => JString("proximity")
-          case Ranking.attribute       => JString("attribute")
-          case Ranking.exact           => JString("exact")
-          case Ranking.custom          => JString("custom")
-          case Ranking.filters         => JString("filters")
+          case Ranking.typo => JString("typo")
+          case Ranking.geo => JString("geo")
+          case Ranking.words => JString("words")
+          case Ranking.proximity => JString("proximity")
+          case Ranking.attribute => JString("attribute")
+          case Ranking.exact => JString("exact")
+          case Ranking.custom => JString("custom")
+          case Ranking.filters => JString("filters")
         }))
 
   class CustomRankingSerializer
       extends CustomSerializer[CustomRanking](_ =>
         ({
-          case JString(asc(attr))  => CustomRanking.asc(attr)
+          case JString(asc(attr)) => CustomRanking.asc(attr)
           case JString(desc(attr)) => CustomRanking.desc(attr)
         }, {
-          case CustomRanking.asc(attribute)  => JString(s"asc($attribute)")
+          case CustomRanking.asc(attribute) => JString(s"asc($attribute)")
           case CustomRanking.desc(attribute) => JString(s"desc($attribute)")
         }))
 
   class QueryTypeSerializer
       extends CustomSerializer[QueryType](_ =>
         ({
-          case JString("prefixAll")  => QueryType.prefixAll
+          case JString("prefixAll") => QueryType.prefixAll
           case JString("prefixLast") => QueryType.prefixLast
           case JString("prefixNone") => QueryType.prefixNone
         }, {
-          case QueryType.prefixAll  => JString("prefixAll")
+          case QueryType.prefixAll => JString("prefixAll")
           case QueryType.prefixLast => JString("prefixLast")
           case QueryType.prefixNone => JString("prefixNone")
         }))
@@ -203,39 +203,39 @@ object AlgoliaDsl extends AlgoliaDsl {
   class TypoToleranceSerializer
       extends CustomSerializer[TypoTolerance](_ =>
         ({
-          case JString("true")   => TypoTolerance.`true`
-          case JString("false")  => TypoTolerance.`false`
-          case JString("min")    => TypoTolerance.min
+          case JString("true") => TypoTolerance.`true`
+          case JString("false") => TypoTolerance.`false`
+          case JString("min") => TypoTolerance.min
           case JString("strict") => TypoTolerance.strict
         }, {
-          case TypoTolerance.`true`  => JString("true")
+          case TypoTolerance.`true` => JString("true")
           case TypoTolerance.`false` => JString("false")
-          case TypoTolerance.min     => JString("min")
-          case TypoTolerance.strict  => JString("strict")
+          case TypoTolerance.min => JString("min")
+          case TypoTolerance.strict => JString("strict")
         }))
 
   class AclSerializer
       extends CustomSerializer[Acl](_ =>
         ({
-          case JString("search")       => Acl.search
-          case JString("browse")       => Acl.browse
-          case JString("addObject")    => Acl.addObject
+          case JString("search") => Acl.search
+          case JString("browse") => Acl.browse
+          case JString("addObject") => Acl.addObject
           case JString("deleteObject") => Acl.deleteObject
-          case JString("deleteIndex")  => Acl.deleteIndex
-          case JString("settings")     => Acl.settings
+          case JString("deleteIndex") => Acl.deleteIndex
+          case JString("settings") => Acl.settings
           case JString("editSettings") => Acl.editSettings
-          case JString("analytics")    => Acl.analytics
-          case JString("listIndexes")  => Acl.listIndexes
+          case JString("analytics") => Acl.analytics
+          case JString("listIndexes") => Acl.listIndexes
         }, {
-          case Acl.search       => JString("search")
-          case Acl.browse       => JString("browse")
-          case Acl.addObject    => JString("addObject")
+          case Acl.search => JString("search")
+          case Acl.browse => JString("browse")
+          case Acl.addObject => JString("addObject")
           case Acl.deleteObject => JString("deleteObject")
-          case Acl.deleteIndex  => JString("deleteIndex")
-          case Acl.settings     => JString("settings")
+          case Acl.deleteIndex => JString("deleteIndex")
+          case Acl.settings => JString("settings")
           case Acl.editSettings => JString("editSettings")
-          case Acl.analytics    => JString("analytics")
-          case Acl.listIndexes  => JString("listIndexes")
+          case Acl.analytics => JString("analytics")
+          case Acl.listIndexes => JString("listIndexes")
         }))
 
   class QuerySynonymsSerializer
@@ -296,23 +296,23 @@ object AlgoliaDsl extends AlgoliaDsl {
   class DistinctSerializer
       extends CustomSerializer[Distinct](_ =>
         ({
-          case JBool(true)  => Distinct.`true`
+          case JBool(true) => Distinct.`true`
           case JBool(false) => Distinct.`false`
-          case JInt(i)      => Distinct.int(i.toInt)
+          case JInt(i) => Distinct.int(i.toInt)
         }, {
-          case Distinct.`true`  => JBool(true)
+          case Distinct.`true` => JBool(true)
           case Distinct.`false` => JBool(false)
-          case Distinct.int(i)  => JInt(i)
+          case Distinct.int(i) => JInt(i)
         }))
 
   class RemoveStopWordsSerializer
       extends CustomSerializer[RemoveStopWords](_ =>
         ({
-          case JBool(true)   => RemoveStopWords.`true`
-          case JBool(false)  => RemoveStopWords.`false`
+          case JBool(true) => RemoveStopWords.`true`
+          case JBool(false) => RemoveStopWords.`false`
           case JString(list) => RemoveStopWords.list(list.split(",").toSeq)
         }, {
-          case RemoveStopWords.`true`  => JBool(true)
+          case RemoveStopWords.`true` => JBool(true)
           case RemoveStopWords.`false` => JBool(false)
           case RemoveStopWords.list(i) => JString(i.mkString(","))
         }))
@@ -320,21 +320,21 @@ object AlgoliaDsl extends AlgoliaDsl {
   class AlternativesSerializer
       extends CustomSerializer[Alternatives](_ =>
         ({
-          case JBool(true)  => Alternatives.`true`
+          case JBool(true) => Alternatives.`true`
           case JBool(false) => Alternatives.`false`
         }, {
-          case Alternatives.`true`  => JBool(true)
+          case Alternatives.`true` => JBool(true)
           case Alternatives.`false` => JBool(false)
         }))
 
   class IgnorePluralsSerializer
       extends CustomSerializer[IgnorePlurals](_ =>
         ({
-          case JBool(true)   => IgnorePlurals.`true`
-          case JBool(false)  => IgnorePlurals.`false`
+          case JBool(true) => IgnorePlurals.`true`
+          case JBool(false) => IgnorePlurals.`false`
           case JString(list) => IgnorePlurals.list(list.split(",").toSeq)
         }, {
-          case IgnorePlurals.`true`  => JBool(true)
+          case IgnorePlurals.`true` => JBool(true)
           case IgnorePlurals.`false` => JBool(false)
           case IgnorePlurals.list(i) => JString(i.mkString(","))
         }))

--- a/src/main/scala/algolia/definitions/BatchDefinition.scala
+++ b/src/main/scala/algolia/definitions/BatchDefinition.scala
@@ -57,7 +57,7 @@ case class BatchDefinition(
     definition match {
       case IndexingDefinition(index, None, Some(obj), _) =>
         hasObjectId(obj) match {
-          case (true, o)  => Iterable(UpdateObjectOperation(o, Some(index)))
+          case (true, o) => Iterable(UpdateObjectOperation(o, Some(index)))
           case (false, o) => Iterable(AddObjectOperation(o, Some(index)))
         }
 

--- a/src/main/scala/algolia/definitions/DeleteDefinition.scala
+++ b/src/main/scala/algolia/definitions/DeleteDefinition.scala
@@ -48,7 +48,7 @@ case class DeleteObjectDefinition(
   def objectId(objectId: String): DeleteObjectDefinition =
     copy(oid = Some(objectId))
 
-  def objectIds(objectIds: Traversable[String]): BatchDefinition =
+  def objectIds(objectIds: Iterable[String]): BatchDefinition =
     BatchDefinition(objectIds.map { oid =>
       DeleteObjectDefinition(index, Some(oid))
     })

--- a/src/main/scala/algolia/definitions/IndexingBatchDefinition.scala
+++ b/src/main/scala/algolia/definitions/IndexingBatchDefinition.scala
@@ -47,7 +47,7 @@ case class IndexingBatchDefinition(
     val operations = definitions.map {
       case IndexingDefinition(_, None, Some(obj), _) =>
         hasObjectId(obj) match {
-          case (true, o)  => UpdateObjectOperation(o)
+          case (true, o) => UpdateObjectOperation(o)
           case (false, o) => AddObjectOperation(o)
         }
 

--- a/src/main/scala/algolia/definitions/IndexingBatchDefinition.scala
+++ b/src/main/scala/algolia/definitions/IndexingBatchDefinition.scala
@@ -33,7 +33,7 @@ import org.json4s.native.Serialization._
 
 case class IndexingBatchDefinition(
     index: String,
-    definitions: Traversable[Definition] = Traversable(),
+    definitions: Iterable[Definition] = Iterable(),
     requestOptions: Option[RequestOptions] = None)(implicit val formats: Formats)
     extends Definition
     with BatchOperationUtils {
@@ -47,7 +47,7 @@ case class IndexingBatchDefinition(
     val operations = definitions.map {
       case IndexingDefinition(_, None, Some(obj), _) =>
         hasObjectId(obj) match {
-          case (true, o) => UpdateObjectOperation(o)
+          case (true, o)  => UpdateObjectOperation(o)
           case (false, o) => AddObjectOperation(o)
         }
 

--- a/src/main/scala/algolia/definitions/IndexingDefinition.scala
+++ b/src/main/scala/algolia/definitions/IndexingDefinition.scala
@@ -52,7 +52,7 @@ case class IndexingDefinition(
         IndexingDefinition(index, Some(oid), Some(o))
     })
 
-  def objects(objects: Traversable[AnyRef]): IndexingBatchDefinition =
+  def objects(objects: Iterable[AnyRef]): IndexingBatchDefinition =
     IndexingBatchDefinition(index, objects.map { obj =>
       copy(index = index, obj = Some(obj))
     })
@@ -70,7 +70,7 @@ case class IndexingDefinition(
     val body: Option[String] = obj.map(o => write(o))
     val verb = objectId match {
       case Some(_) => http.PUT
-      case None => http.POST
+      case None    => http.POST
     }
 
     HttpPayload(verb,

--- a/src/main/scala/algolia/definitions/IndexingDefinition.scala
+++ b/src/main/scala/algolia/definitions/IndexingDefinition.scala
@@ -70,7 +70,7 @@ case class IndexingDefinition(
     val body: Option[String] = obj.map(o => write(o))
     val verb = objectId match {
       case Some(_) => http.PUT
-      case None    => http.POST
+      case None => http.POST
     }
 
     HttpPayload(verb,

--- a/src/main/scala/algolia/definitions/MultiQueriesDefinition.scala
+++ b/src/main/scala/algolia/definitions/MultiQueriesDefinition.scala
@@ -32,7 +32,7 @@ import org.json4s.Formats
 import org.json4s.native.Serialization._
 
 case class MultiQueriesDefinition(
-    definitions: Traversable[SearchDefinition],
+    definitions: Iterable[SearchDefinition],
     strategy: Option[MultiQueries.Strategy] = None,
     requestOptions: Option[RequestOptions] = None)(implicit val formats: Formats)
     extends Definition {

--- a/src/main/scala/algolia/dsl/BatchDsl.scala
+++ b/src/main/scala/algolia/dsl/BatchDsl.scala
@@ -36,7 +36,7 @@ trait BatchDsl {
 
   implicit val formats: Formats
 
-  def batch(batches: Traversable[Definition]): BatchDefinition = {
+  def batch(batches: Iterable[Definition]): BatchDefinition = {
     BatchDefinition(batches)
   }
 

--- a/src/main/scala/algolia/dsl/MultiQueriesDefinitionDsl.scala
+++ b/src/main/scala/algolia/dsl/MultiQueriesDefinitionDsl.scala
@@ -37,7 +37,7 @@ trait MultiQueriesDefinitionDsl {
   implicit val formats: Formats
 
   @deprecated("use multipleQueries", "1.27.1")
-  def multiQueries(queries: Traversable[SearchDefinition]): MultiQueriesDefinition = {
+  def multiQueries(queries: Iterable[SearchDefinition]): MultiQueriesDefinition = {
     MultiQueriesDefinition(queries)
   }
 
@@ -46,7 +46,7 @@ trait MultiQueriesDefinitionDsl {
     MultiQueriesDefinition(queries)
   }
 
-  def multipleQueries(queries: Traversable[SearchDefinition]): MultiQueriesDefinition = {
+  def multipleQueries(queries: Iterable[SearchDefinition]): MultiQueriesDefinition = {
     MultiQueriesDefinition(queries)
   }
 

--- a/src/main/scala/algolia/http/HttpPayload.scala
+++ b/src/main/scala/algolia/http/HttpPayload.scala
@@ -29,7 +29,7 @@ import java.net.InetAddress
 
 import algolia.objects.RequestOptions
 import io.netty.resolver.NameResolver
-import com.netaporter.uri.dsl._
+import io.lemonlabs.uri.dsl._
 import org.asynchttpclient.{Request, RequestBuilder}
 
 private[algolia] sealed trait HttpVerb

--- a/src/main/scala/algolia/inputs/BatchOperations.scala
+++ b/src/main/scala/algolia/inputs/BatchOperations.scala
@@ -25,7 +25,7 @@
 
 package algolia.inputs
 
-case class BatchOperations(requests: Traversable[BatchOperation[_ <: AnyRef]])
+case class BatchOperations(requests: Iterable[BatchOperation[_ <: AnyRef]])
 
 sealed trait BatchOperation[T <: AnyRef] {
 

--- a/src/main/scala/algolia/inputs/MultiQueriesRequests.scala
+++ b/src/main/scala/algolia/inputs/MultiQueriesRequests.scala
@@ -25,6 +25,6 @@
 
 package algolia.inputs
 
-case class MultiQueriesRequests(requests: Traversable[MultiQueriesRequest])
+case class MultiQueriesRequests(requests: Iterable[MultiQueriesRequest])
 
 case class MultiQueriesRequest(indexName: String, params: Option[String])

--- a/src/test/scala/algolia/AlgoliaClientTest.scala
+++ b/src/test/scala/algolia/AlgoliaClientTest.scala
@@ -318,8 +318,8 @@ class AlgoliaClientTest extends AlgoliaTest {
 
         apiClient.hostsStatuses.hostStatuses.asScala should be(
           Map(
-            "https://a-dsn.algolia.net" -> HostStatus(up = false, 1l),
-            "https://a-1.algolianet.com" -> HostStatus(up = true, 1l)
+            "https://a-dsn.algolia.net" -> HostStatus(up = false, 1L),
+            "https://a-1.algolianet.com" -> HostStatus(up = true, 1L)
           ))
 
         mockRequest1 returning Future.successful(successfulRequest1)
@@ -332,8 +332,8 @@ class AlgoliaClientTest extends AlgoliaTest {
 
         apiClient.hostsStatuses.hostStatuses.asScala should be(
           Map(
-            "https://a-dsn.algolia.net" -> HostStatus(up = false, 1l),
-            "https://a-1.algolianet.com" -> HostStatus(up = true, 1l)
+            "https://a-dsn.algolia.net" -> HostStatus(up = false, 1L),
+            "https://a-1.algolianet.com" -> HostStatus(up = true, 1L)
           ))
       }
 
@@ -478,8 +478,8 @@ class AlgoliaClientTest extends AlgoliaTest {
     val apiClient = new AlgoliaClient("APPID", "APIKEY")
 
     it("should generate a secured api key") {
-      val secureApiKey = apiClient.generateSecuredApiKey("PRIVATE_API_KEY",
-                                                         Query(tagFilters = Some(Seq("user_42"))))
+      val secureApiKey =
+        apiClient.generateSecuredApiKey("PRIVATE_API_KEY", Query(tagFilters = Some(Seq("user_42"))))
       secureApiKey should be(
         "ZWRjMDQyY2Y0MDM1OThiZjM0MmEyM2VlNjVmOWY2YTczYzc3YWJiMzdhMjIzMDY5M2VmY2RjNmQ0MmI5NWU3NHRhZ0ZpbHRlcnM9dXNlcl80Mg==")
     }

--- a/src/test/scala/algolia/AlgoliaClientTest.scala
+++ b/src/test/scala/algolia/AlgoliaClientTest.scala
@@ -479,7 +479,8 @@ class AlgoliaClientTest extends AlgoliaTest {
 
     it("should generate a secured api key") {
       val secureApiKey =
-        apiClient.generateSecuredApiKey("PRIVATE_API_KEY", Query(tagFilters = Some(Seq("user_42"))))
+        apiClient.generateSecuredApiKey("PRIVATE_API_KEY",
+                                        Query(tagFilters = Some(Seq("user_42"))))
       secureApiKey should be(
         "ZWRjMDQyY2Y0MDM1OThiZjM0MmEyM2VlNjVmOWY2YTczYzc3YWJiMzdhMjIzMDY5M2VmY2RjNmQ0MmI5NWU3NHRhZ0ZpbHRlcnM9dXNlcl80Mg==")
     }

--- a/src/test/scala/algolia/NetworkTest.scala
+++ b/src/test/scala/algolia/NetworkTest.scala
@@ -30,6 +30,7 @@ import java.util.concurrent.{ExecutionException, TimeUnit}
 
 import algolia.AlgoliaDsl._
 import org.scalatest.DoNotDiscover
+import org.scalatest.TryValues._
 
 import scala.concurrent.duration._
 import scala.util.Try
@@ -55,9 +56,8 @@ class NetworkTest extends AlgoliaTest {
     it("should answer within 200 * 6 milliseconds") {
       val request = apiClient.httpClient.dnsNameResolver.resolve("https://scala-dsn.algolia.biz")
       val result = Try(request.get(200 * 6, TimeUnit.MILLISECONDS))
-      result shouldBe 'failure
-      result.failed.get shouldBe a[ExecutionException]
-      result.failed.get.getCause shouldBe a[UnknownHostException]
+      result.failure.exception shouldBe a[ExecutionException]
+      result.failure.exception.getCause shouldBe a[UnknownHostException]
     }
 
     it("should answer within 1 minute") {


### PR DESCRIPTION
Resolves #554

* Upgrade json4s to 3.6.7
* Upgrade scala-uri to 1.4.10
* Upgrade scalacheck to 1.14.2
* Upgrade scalamock to 4.4.0
* Upgrade Scala 2.11 to latest 2.11.12
* Upgrade Scala 2.12 to latest 2.12.10
* Add cross build for Scala 2.13.1

* Resolve Scala 2.13 deprecations:
   * Traversable -> Iterable