### PR TITLE
fix(search): correctly type automaticRadius field of search response

### DIFF
--- a/src/main/scala/algolia/responses/SearchResult.scala
+++ b/src/main/scala/algolia/responses/SearchResult.scala
@@ -48,7 +48,7 @@ case class SearchResult(hits: Seq[JObject],
                         params: String,
                         message: Option[String],
                         aroundLatLng: Option[String],
-                        automaticRadius: Option[Int],
+                        automaticRadius: Option[String],
                         facets_stats: Option[Map[String, Float]],
                         // For getRankingInfo
                         serverUsed: Option[String],


### PR DESCRIPTION
Fix #539
