### PR TITLE
feat(rule): implement multi-condition rules

### DIFF
--- a/src/main/scala/algolia/objects/Rule.scala
+++ b/src/main/scala/algolia/objects/Rule.scala
@@ -28,7 +28,8 @@ package algolia.objects
 case class Rule(
     objectID: String,
     enabled: Option[Boolean] = None,
-    condition: Condition,
+    condition: Option[Condition] = None,
+    conditions: Option[Iterable[Condition]] = None,
     consequence: Consequence,
     validity: Option[Iterable[TimeRange]] = None,
     description: Option[String] = None

--- a/src/test/scala/algolia/AlgoliaTest.scala
+++ b/src/test/scala/algolia/AlgoliaTest.scala
@@ -181,9 +181,11 @@ class AlgoliaTest
   def generateRule(ruleId: String): Rule = {
     Rule(
       objectID = ruleId,
-      condition = Condition(
-        pattern = "a",
-        anchoring = "is"
+      condition = Some(
+        Condition(
+          pattern = "a",
+          anchoring = "is"
+        )
       ),
       consequence = Consequence(
         params = Some(

--- a/src/test/scala/algolia/dsl/RulesTest.scala
+++ b/src/test/scala/algolia/dsl/RulesTest.scala
@@ -154,9 +154,11 @@ class RulesTest extends AlgoliaTest {
       it("should serialize correctly") {
         val rule = Rule(
           objectID = "rule1",
-          condition = Condition(
-            pattern = "a",
-            anchoring = "is"
+          condition = Some(
+            Condition(
+              pattern = "a",
+              anchoring = "is"
+            )
           ),
           consequence = Consequence(
             params = Some(Map("query" -> "1")),
@@ -179,13 +181,44 @@ class RulesTest extends AlgoliaTest {
         )
       }
 
+      it("should serialize correctly a multi-condition rule") {
+        val rule = Rule(
+          objectID = "rule1",
+          conditions = Some(
+            Seq(
+              Condition(pattern = "a", anchoring = "is")
+            )
+          ),
+          consequence = Consequence(
+            params = Some(Map("query" -> "1")),
+            userData = Some(Map("a" -> "b"))
+          )
+        )
+
+        (save rule rule inIndex "toto" and forwardToReplicas)
+          .build() should be(
+          HttpPayload(
+            PUT,
+            Seq("1", "indexes", "toto", "rules", "rule1"),
+            queryParameters = Some(Map("forwardToReplicas" -> "true")),
+            body = Some(
+              """{"objectID":"rule1","conditions":[{"pattern":"a","anchoring":"is"}],"consequence":{"params":{"query":"1"},"userData":{"a":"b"}}}"""
+            ),
+            isSearch = false,
+            requestOptions = None
+          )
+        )
+      }
+
       it("should serialize correctly with enabled flag") {
         val rule = Rule(
           objectID = "rule1",
           enabled = Some(true),
-          condition = Condition(
-            pattern = "a",
-            anchoring = "is"
+          condition = Some(
+            Condition(
+              pattern = "a",
+              anchoring = "is"
+            )
           ),
           consequence = Consequence(
             params = Some(Map("query" -> "1")),
@@ -226,9 +259,11 @@ class RulesTest extends AlgoliaTest {
           objectID = "rule1",
           enabled = Some(true),
           validity = Some(Seq(TimeRange(from, until))),
-          condition = Condition(
-            pattern = "a",
-            anchoring = "is"
+          condition = Some(
+            Condition(
+              pattern = "a",
+              anchoring = "is"
+            )
           ),
           consequence = Consequence(
             params = Some(Map("query" -> "1")),
@@ -254,9 +289,11 @@ class RulesTest extends AlgoliaTest {
       it("should serialize correctly with promote and hide") {
         val rule = Rule(
           objectID = "rule1",
-          condition = Condition(
-            pattern = "a",
-            anchoring = "is"
+          condition = Some(
+            Condition(
+              pattern = "a",
+              anchoring = "is"
+            )
           ),
           consequence = Consequence(
             promote = Some(
@@ -292,9 +329,11 @@ class RulesTest extends AlgoliaTest {
       it("should serialize correctly with automatic facet filters") {
         val rule = Rule(
           objectID = "rule1",
-          condition = Condition(
-            pattern = "{facet:brand}",
-            anchoring = "is"
+          condition = Some(
+            Condition(
+              pattern = "{facet:brand}",
+              anchoring = "is"
+            )
           ),
           consequence = Consequence(
             params = Some(
@@ -325,9 +364,11 @@ class RulesTest extends AlgoliaTest {
       it("should serialize correctly with edits") {
         val rule = Rule(
           objectID = "rule1",
-          condition = Condition(
-            pattern = "toto",
-            anchoring = "is"
+          condition = Some(
+            Condition(
+              pattern = "toto",
+              anchoring = "is"
+            )
           ),
           consequence = Consequence(
             params = Some(

--- a/src/test/scala/algolia/integration/RulesIntegrationTest.scala
+++ b/src/test/scala/algolia/integration/RulesIntegrationTest.scala
@@ -197,9 +197,11 @@ class RulesIntegrationTest extends AlgoliaTest {
     it("should save rule with automatic facet filters") {
       val rule = Rule(
         objectID = "RuleAutomaticFacetFilters",
-        condition = Condition(
-          pattern = "{facet:brand}",
-          anchoring = "is"
+        condition = Some(
+          Condition(
+            pattern = "{facet:brand}",
+            anchoring = "is"
+          )
         ),
         consequence = Consequence(
           params = Some(
@@ -241,10 +243,12 @@ class RulesIntegrationTest extends AlgoliaTest {
         objectID = "RuleTimeRange",
         enabled = Some(true),
         validity = Some(Seq(TimeRange(from, until))),
-        condition = Condition(
-          pattern = "a",
-          anchoring = "is",
-          alternatives = Some(Alternatives.`true`)
+        condition = Some(
+          Condition(
+            pattern = "a",
+            anchoring = "is",
+            alternatives = Some(Alternatives.`true`)
+          )
         ),
         consequence = Consequence(
           filterPromotes = Some(false),
@@ -272,9 +276,11 @@ class RulesIntegrationTest extends AlgoliaTest {
     it("should save rule with edits") {
       val rule = Rule(
         objectID = "RuleEdits",
-        condition = Condition(
-          pattern = "toto",
-          anchoring = "is"
+        condition = Some(
+          Condition(
+            pattern = "toto",
+            anchoring = "is"
+          )
         ),
         consequence = Consequence(
           params = Some(
@@ -318,9 +324,11 @@ class RulesIntegrationTest extends AlgoliaTest {
 
       val rule = Rule(
         objectID = "RulePromoteAndHide",
-        condition = Condition(
-          pattern = "a",
-          anchoring = "is"
+        condition = Some(
+          Condition(
+            pattern = "a",
+            anchoring = "is"
+          )
         ),
         consequence = Consequence(
           hide = Some(Seq(ConsequenceHide("2"))),


### PR DESCRIPTION
Close #591 

This is a breaking change since the `Rule.condition` field type has to be
changed from `Condition` to `Option[Condition]`. IMHO it's fine to break the
compatibility here since the condition type was incorrect in the first place,
and it's more important to stay align as much as we can with other API clients.
