### PR TITLE
chore(ci): fix release step environment variables checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,8 +94,8 @@ jobs:
       - run:
           name: Release new version
           command: |
-            if [ -z "BINTRAY_USER" ]; then echo "BINTRAY_USER is not set";  exit 1; fi
-            if [ -z "BINTRAY_PASS" ]; then echo "BINTRAY_PASS is not set";  exit 1; fi
+            if [[ -z "$BINTRAY_USER" ]]; then echo '$BINTRAY_USER is not set';  exit 1; fi
+            if [[ -z "$BINTRAY_PASS" ]]; then echo '$BINTRAY_PASS is not set';  exit 1; fi
             cat /dev/null | sbt '+publish'
 
 workflows:


### PR DESCRIPTION
This commit fixes the environment variable shell expansion in the
release step of the CircleCI configuration. It also makes sure the
variables are not expanded when displaying the error message.