### PR TITLE
Remove dependency on scala-uri

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,6 @@ lazy val root = project
   )
 
 // Project dependencies
-libraryDependencies += "io.lemonlabs" %% "scala-uri" % "1.4.10"
 libraryDependencies += "org.asynchttpclient" % "async-http-client" % "2.10.5"
 libraryDependencies += "io.netty" % "netty-resolver-dns" % "4.1.45.Final"
 libraryDependencies += "org.json4s" %% "json4s-ast" % "3.6.7"

--- a/src/main/scala/algolia/http/HttpPayload.scala
+++ b/src/main/scala/algolia/http/HttpPayload.scala
@@ -29,7 +29,6 @@ import java.net.InetAddress
 
 import algolia.objects.RequestOptions
 import io.netty.resolver.NameResolver
-import io.lemonlabs.uri.dsl._
 import org.asynchttpclient.{Request, RequestBuilder}
 
 private[algolia] sealed trait HttpVerb
@@ -67,7 +66,7 @@ private[algolia] case class HttpPayload(
       headers: Map[String, String],
       dnsNameResolver: NameResolver[InetAddress]
   ): Request = {
-    val uri = path.foldLeft(host)((url, p) => url / p)
+    val uri = path.foldLeft(host)((url, p) => appendPath(url, p))
 
     var builder: RequestBuilder =
       new RequestBuilder().setMethod(verb.toString).setUrl(uri)
@@ -107,6 +106,12 @@ private[algolia] case class HttpPayload(
     val _body = body.map(b => s", '$b'").getOrElse("")
 
     s"$verb $host${_path}${_query}${_body}"
+  }
+
+  private def appendPath(url: String, path: String ) = if(url.endsWith("/")) {
+    url + path
+  } else {
+    url + "/" + path
   }
 
 }

--- a/src/main/scala/algolia/http/HttpPayload.scala
+++ b/src/main/scala/algolia/http/HttpPayload.scala
@@ -108,10 +108,11 @@ private[algolia] case class HttpPayload(
     s"$verb $host${_path}${_query}${_body}"
   }
 
-  private def appendPath(url: String, path: String ) = if(url.endsWith("/")) {
-    url + path
-  } else {
-    url + "/" + path
-  }
+  private def appendPath(url: String, path: String) =
+    if (url.endsWith("/")) {
+      url + path
+    } else {
+      url + "/" + path
+    }
 
 }

--- a/src/main/scala/algolia/http/HttpPayload.scala
+++ b/src/main/scala/algolia/http/HttpPayload.scala
@@ -66,7 +66,7 @@ private[algolia] case class HttpPayload(
       headers: Map[String, String],
       dnsNameResolver: NameResolver[InetAddress]
   ): Request = {
-    val uri = path.foldLeft(host)((url, p) => appendPath(url, p))
+    val uri = path.foldLeft(host)((url, p) => insertPath(url, p))
 
     var builder: RequestBuilder =
       new RequestBuilder().setMethod(verb.toString).setUrl(uri)
@@ -107,6 +107,12 @@ private[algolia] case class HttpPayload(
 
     s"$verb $host${_path}${_query}${_body}"
   }
+
+  private def insertPath(url: String, path: String) =
+    url.indexOf('?') match {
+      case -1 => appendPath(url, path)
+      case i  => appendPath(url.substring(0, i), path) + url.substring(i)
+    }
 
   private def appendPath(url: String, path: String) =
     if (url.endsWith("/")) {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | 
| Need Doc update   | no


## Describe your change

Remove dependency on `"io.lemonlabs" %% "scala-uri"`.

## What problem is this fixing?

Libraries like `algolia-clieant-scala` are intended for use in many different applications built by Algolia's clients. 
It's in the interest of library maintainer to make extra effort to minimize 3rd party dependencies. All in order to prevent
possible transitive library version conflicts for their users.

For example, since we needed some functionality that comes with `scala-uri` 2.x, we had to go into
a hassle to "shade" `algolia-client-scala` and it's dependencies to avoid version conflict with
`scala-uri` 1.x.
 
`scala-uri` is only minimally used here, so there doesn't seem a big problem to remove it.