### PR TITLE
Added dot(.) as a valid in an attribute name for the deserialization

### DIFF
--- a/src/main/scala/algolia/AlgoliaDsl.scala
+++ b/src/main/scala/algolia/AlgoliaDsl.scala
@@ -91,13 +91,13 @@ object AlgoliaDsl extends AlgoliaDsl {
       new ZonedDateTimeSerializer +
       new AlternativesSerializer
 
-  val searchableAttributesUnordered: Regex = """^unordered\(([\w-]+)\)$""".r
+  val searchableAttributesUnordered: Regex = """^unordered\(([\w-\\.]+)\)$""".r
   val searchableAttributesAttributes: Regex =
-    """^([\w-]+,[\w-]+[,[\w-]+]*)$""".r
+    """^([\w-\\.]+,[\w-\\.]+[,[\w-\\.]+]*)$""".r
   val numericAttributesToIndexEqualOnly: Regex =
-    """^equalOnly\(([\w-]+)\)$""".r
-  val asc: Regex = """^asc\(([\w-]+)\)$""".r
-  val desc: Regex = """^desc\(([\w-]+)\)$""".r
+    """^equalOnly\(([\w-\\.]+)\)$""".r
+  val asc: Regex = """^asc\(([\w-\\.]+)\)$""".r
+  val desc: Regex = """^desc\(([\w-\\.]+)\)$""".r
 
   sealed trait ForwardToReplicas
 

--- a/src/test/scala/algolia/dsl/IndexSettingsTest.scala
+++ b/src/test/scala/algolia/dsl/IndexSettingsTest.scala
@@ -116,7 +116,8 @@ class IndexSettingsTest extends AlgoliaTest {
         |  ],
         |  "customRanking":[
         |    "asc(att8)",
-        |    "desc(att9)"
+        |    "desc(att9)",
+        |    "desc(nested.att10)"
         |  ],
         |  "typoTolerance":"strict",
         |  "ignorePlurals":"fr,en"
@@ -169,7 +170,8 @@ class IndexSettingsTest extends AlgoliaTest {
             Some(
               Seq(
                 CustomRanking.asc("att8"),
-                CustomRanking.desc("att9")
+                CustomRanking.desc("att9"),
+                CustomRanking.desc("nested.att10")
               )
             )
           )
@@ -221,7 +223,8 @@ class IndexSettingsTest extends AlgoliaTest {
         customRanking = Some(
           Seq(
             CustomRanking.asc("att8"),
-            CustomRanking.desc("att9")
+            CustomRanking.desc("att9"),
+            CustomRanking.desc("nested.att10")
           )
         ),
         ignorePlurals = Some(IgnorePlurals.list(Seq("fr", "en"))),


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      |no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #...  <!-- will close issue automatically, if any -->
| Need Doc update   | /no


## Describe your change
For the deserialization, added dots a a valid part of an attribute, since this is how you denote nested attributes.

<!-- 
    Please describe your change, add as much detail as 
    necessary to understand your code.
-->

## What problem is this fixing?
Nested attributes caused the deserialization to fail. I.e. one customer ranking nested attribute caused a failure of the deserialization of the full list of customer rankings.

Modified "IndexSettings serialization/deserialization" unit test with this scenario.

<!-- 
    Please include everything needed to understand the problem, 
    its context and consequences, and, if possible, how to recreate it.
-->

