### PR TITLE
fix(analytics): check if the type of AB testing average click positio…

### DIFF
--- a/src/main/scala/algolia/responses/ABTest.scala
+++ b/src/main/scala/algolia/responses/ABTest.scala
@@ -43,7 +43,7 @@ case class ABTestResponse(
 )
 
 case class VariantResponse(
-    averageClickPosition: Option[Int],
+    averageClickPosition: Option[Float],
     clickCount: Option[Int],
     clickThroughRate: Option[Float],
     conversionCount: Option[Int],


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | yes     
| Related Issue     | https://github.com/algolia/algoliasearch-client-specs-internal/issues/143 
| Need Doc update   | no


## Describe your change

The type of `averageClickPosition` field in variant response structure must be `Float`.
