### PR TITLE
feat(analytics): add trackedSearchCount to variant response

### DIFF
--- a/src/main/scala/algolia/responses/ABTest.scala
+++ b/src/main/scala/algolia/responses/ABTest.scala
@@ -54,5 +54,6 @@ case class VariantResponse(
     searchCount: Option[Int],
     trafficPercentage: Int,
     userCount: Option[Int],
-    customSearchParameters: Option[Query]
+    customSearchParameters: Option[Query],
+    trackedSearchCount: Option[Int]
 )


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Need Doc update   | no


## Describe your change

add `trackedSearchCount` field to `VariantResponse`
