### PR TITLE
refact(search): `replaceExistingSynonyms` to `clearExistingSynonyms`

### DIFF
--- a/src/main/scala/algolia/AlgoliaDsl.scala
+++ b/src/main/scala/algolia/AlgoliaDsl.scala
@@ -103,7 +103,10 @@ object AlgoliaDsl extends AlgoliaDsl {
 
   sealed trait ClearExistingRules
 
+  @deprecated("Use ClearExistingSynonyms instead")
   sealed trait ReplaceExistingSynonyms
+
+  sealed trait ClearExistingSynonyms
 
   sealed trait Of
 
@@ -415,7 +418,10 @@ object AlgoliaDsl extends AlgoliaDsl {
 
   case object forwardToReplicas extends ForwardToReplicas
 
+  @deprecated("Use clearExistingSynonyms instead")
   case object replaceExistingSynonyms extends ReplaceExistingSynonyms
+
+  case object clearExistingSynonyms extends ClearExistingSynonyms
 
   case object clearExistingRules extends ClearExistingRules
 

--- a/src/main/scala/algolia/definitions/SynonymsDefinition.scala
+++ b/src/main/scala/algolia/definitions/SynonymsDefinition.scala
@@ -25,7 +25,12 @@
 
 package algolia.definitions
 
-import algolia.AlgoliaDsl.{ForwardToReplicas, ReplaceExistingSynonyms}
+import algolia.AlgoliaDsl.{
+  ClearExistingSynonyms,
+  ForwardToReplicas,
+  ReplaceExistingSynonyms,
+  clearExistingSynonyms
+}
 import algolia.http._
 import algolia.objects.{AbstractSynonym, QuerySynonyms, RequestOptions}
 import org.json4s.Formats
@@ -174,7 +179,7 @@ case class BatchSynonymsDefinition(
     synonyms: Iterable[AbstractSynonym],
     index: Option[String] = None,
     forward: Option[ForwardToReplicas] = None,
-    replace: Option[ReplaceExistingSynonyms] = None,
+    replace: Option[ClearExistingSynonyms] = None,
     requestOptions: Option[RequestOptions] = None
 )(implicit val formats: Formats)
     extends Definition {
@@ -187,7 +192,11 @@ case class BatchSynonymsDefinition(
   def and(forward: ForwardToReplicas): BatchSynonymsDefinition =
     copy(forward = Some(forward))
 
+  @deprecated("Use ClearExistingSynonyms instead")
   def and(replace: ReplaceExistingSynonyms): BatchSynonymsDefinition =
+    and(clearExistingSynonyms)
+
+  def and(replace: ClearExistingSynonyms): BatchSynonymsDefinition =
     copy(replace = Some(replace))
 
   override def options(

--- a/src/test/scala/algolia/dsl/SynonymsTest.scala
+++ b/src/test/scala/algolia/dsl/SynonymsTest.scala
@@ -26,6 +26,7 @@
 package algolia.dsl
 
 import algolia.AlgoliaDsl._
+import algolia.definitions.BatchSynonymsDefinition
 import algolia.http._
 import algolia.objects.Synonym.Placeholder
 import algolia.objects.{QuerySynonyms, SynonymType}
@@ -159,12 +160,12 @@ class SynonymsTest extends AlgoliaTest {
     describe("batch") {
 
       it("should save batches synonyms of an index") {
-        save synonyms Seq(Placeholder("oid", "1", Seq("2", "3"))) inIndex "toto" and forwardToSlaves and replaceExistingSynonyms
-        save synonyms Seq(Placeholder("oid", "1", Seq("2", "3"))) inIndex "toto" and forwardToReplicas and replaceExistingSynonyms
+        save synonyms Seq(Placeholder("oid", "1", Seq("2", "3"))) inIndex "toto" and forwardToSlaves and clearExistingSynonyms
+        save synonyms Seq(Placeholder("oid", "1", Seq("2", "3"))) inIndex "toto" and forwardToReplicas and clearExistingSynonyms
       }
 
       it("should call API") {
-        (save synonyms Seq(Placeholder("oid", "1", Seq("2", "3"))) inIndex "toto" and forwardToReplicas and replaceExistingSynonyms)
+        (save synonyms Seq(Placeholder("oid", "1", Seq("2", "3"))) inIndex "toto" and forwardToReplicas and clearExistingSynonyms)
           .build() should be(
           HttpPayload(
             POST,


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | yes (TBC)   
| Related Issue     | Fix #609
| Need Doc update   | yes


## Describe your change

Rename `saveSynonyms`'s  `replaceExistingSynonyms` to `clearExistingSynonyms` for consistency. 