### PR TITLE
feat(rules): client side information consequence in rules

### DIFF
--- a/src/main/scala/algolia/objects/Rule.scala
+++ b/src/main/scala/algolia/objects/Rule.scala
@@ -48,9 +48,20 @@ case class Consequence(
     filterPromotes: Option[Boolean] = None,
     promote: Option[Iterable[ConsequencePromote]] = None,
     hide: Option[Iterable[ConsequenceHide]] = None,
-    userData: Option[Map[String, Any]] = None
+    userData: Option[Map[String, Any]] = None,
+    renderingContent: Option[RenderingContent] = None
 )
 
 case class ConsequencePromote(objectID: String, position: Int)
 
 case class ConsequenceHide(objectID: String)
+
+case class RenderingContent(
+    redirect: Redirect,
+    facetMerchandising: FacetMerchandising,
+    userData: Option[Map[String, Any]] = None
+)
+
+case class Redirect(url: String)
+
+case class FacetMerchandising(order: Seq[String])

--- a/src/test/scala/algolia/dsl/RulesTest.scala
+++ b/src/test/scala/algolia/dsl/RulesTest.scala
@@ -25,12 +25,12 @@
 
 package algolia.dsl
 
-import java.time.{ZoneId, ZonedDateTime}
-
 import algolia.AlgoliaDsl._
 import algolia.http._
 import algolia.objects._
 import algolia.{AlgoliaDsl, AlgoliaTest}
+
+import java.time.{ZoneId, ZonedDateTime}
 
 class RulesTest extends AlgoliaTest {
 
@@ -162,7 +162,14 @@ class RulesTest extends AlgoliaTest {
           ),
           consequence = Consequence(
             params = Some(Map("query" -> "1")),
-            userData = Some(Map("a" -> "b"))
+            userData = Some(Map("a" -> "b")),
+            renderingContent = Some(
+              RenderingContent(
+                redirect = Redirect("http://algolia.com/scala"),
+                facetMerchandising = FacetMerchandising(order = Seq("brand")),
+                userData = Some(Map("a" -> "b"))
+              )
+            )
           )
         )
 
@@ -173,10 +180,10 @@ class RulesTest extends AlgoliaTest {
             Seq("1", "indexes", "toto", "rules", "rule1"),
             queryParameters = Some(Map("forwardToReplicas" -> "true")),
             body = Some(
-              """{"objectID":"rule1","condition":{"pattern":"a","anchoring":"is"},"consequence":{"params":{"query":"1"},"userData":{"a":"b"}}}"""
+              """{"objectID":"rule1","condition":{"pattern":"a","anchoring":"is"},"consequence":{"params":{"query":"1"},"userData":{"a":"b"},"renderingContent":{"redirect":{"url":"http://algolia.com/scala"},"facetMerchandising":{"order":["brand"]},"userData":{"a":"b"}}}}"""
             ),
             isSearch = false,
-            requestOptions = None
+            requestOptions = None,
           )
         )
       }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | Fix #612 
| Need Doc update   | yes


## Describe your change

Adds the new consequence `consequence.renderingContent`, which contains an object where each top level attribute is restricted to known use cases. The currently identified use cases are:
* Redirect
* Facet merchandising / ordering
* User defined data