### PR TITLE
feat(virtual indices): Virtual indices related parameters

### DIFF
--- a/src/main/scala/algolia/objects/IndexSettings.scala
+++ b/src/main/scala/algolia/objects/IndexSettings.scala
@@ -101,5 +101,7 @@ case class IndexSettings(
     disableTypoToleranceOnWords: Option[Seq[String]] = None,
     separatorsToIndex: Option[String] = None,
     /* Facets ordering */
-    renderingContent: Option[RenderingContent] = None
+    renderingContent: Option[RenderingContent] = None,
+    /* Virtual Indices */
+    relevancyStrictness: Option[Int] = None
 )

--- a/src/main/scala/algolia/objects/Query.scala
+++ b/src/main/scala/algolia/objects/Query.scala
@@ -116,7 +116,9 @@ case class Query(
     /* Personalization */
     enablePersonalization: Option[Boolean] = None,
     /* CUSTOM */
-    customParameters: Option[Map[String, String]] = None
+    customParameters: Option[Map[String, String]] = None,
+    /* Virtual Indices */
+    relevancyStrictness: Option[Int] = None
 ) {
 
   def toParam: String = {
@@ -220,7 +222,9 @@ case class Query(
       "restrictIndices" -> restrictIndices.map(_.mkString(",")),
       "restrictSources" -> restrictSources.map(_.mkString(",")),
       /* Browse */
-      "cursor" -> cursor
+      "cursor" -> cursor,
+      /* Virtual Indices */
+      "relevancyStrictness" -> relevancyStrictness.map(_.toString)
     ).filter { case (_, v) => v.isDefined }
       .map { case (k, v) => k -> v.get }
 

--- a/src/main/scala/algolia/responses/SearchResult.scala
+++ b/src/main/scala/algolia/responses/SearchResult.scala
@@ -60,6 +60,9 @@ case class SearchResult(
     index: Option[String],
     // advanced
     explain: Option[Explain],
+    // virtual indices
+    appliedRelevancyStrictness: Option[Integer],
+    nbSortedHits: Option[Int],
     // Facets ordering
     renderingContent: Option[RenderingContent]
 ) {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Need Doc update   | yes


## Describe your change

Virtual indices feature (aka virtual replicas) provides a few new parameters:

Search & Settings parameters:
* **relevancyStrictness** 
  - integer value [0-100]  
  - relevancy score to apply to search in virtual index. Bigger value means less, but more relevant results, lesser value - more less relevant results

Search response:
* **appliedRelevancyStrictness** 
  - integer value [0-100]
  - relevancy score to apply to the search in virtual index. 
* **nbSortedHits** 
   - integer value
   - number of relevant hits to display in case of non-zero `relevancyStrictness` applied