### PR TITLE
refact: batch delete operation serialization

### DIFF
--- a/src/main/scala/algolia/AlgoliaDsl.scala
+++ b/src/main/scala/algolia/AlgoliaDsl.scala
@@ -424,7 +424,8 @@ object AlgoliaDsl extends AlgoliaDsl {
 
   def deleteObjectOperationSerializer
       : PartialFunction[(String, Any), Option[(String, Any)]] = {
-    case "objectID" -> objectID => Some("body" -> ("objectID" -> objectID))
+    case Tuple2("objectID", objectID) =>
+      Some("body" -> ("objectID" -> objectID))
   }
 
   case object forwardToSlaves extends ForwardToReplicas

--- a/src/main/scala/algolia/AlgoliaDsl.scala
+++ b/src/main/scala/algolia/AlgoliaDsl.scala
@@ -27,7 +27,9 @@ package algolia
 
 import algolia.definitions._
 import algolia.dsl._
+import algolia.inputs.DeleteObjectOperation
 import algolia.objects._
+import org.json4s
 import org.json4s.JsonAST._
 import org.json4s.JsonDSL._
 import org.json4s.{CustomSerializer, FieldSerializer, Formats, JField}
@@ -90,9 +92,8 @@ object AlgoliaDsl extends AlgoliaDsl {
       new LocalDateTimeSerializer +
       new ZonedDateTimeSerializer +
       new AlternativesSerializer +
-      new FieldSerializer[IndexSettings](
-        deserializer = numericAttributesToIndexDeserializer
-      )
+      new FieldSerializer[IndexSettings](deserializer = numericAttributesToIndexDeserializer) +
+      new FieldSerializer[DeleteObjectOperation[JValue]](serializer = deleteObjectOperationSerializer)
 
   val searchableAttributesUnordered: Regex = """^unordered\(([\w-\\.]+)\)$""".r
   val searchableAttributesAttributes: Regex =
@@ -415,6 +416,10 @@ object AlgoliaDsl extends AlgoliaDsl {
           }
         )
       )
+  }
+
+  def deleteObjectOperationSerializer: PartialFunction[(String, Any), Option[(String, Any)]] = {
+    case "objectID" -> objectID => Some("body" -> ("objectID" -> objectID))
   }
 
   case object forwardToSlaves extends ForwardToReplicas

--- a/src/main/scala/algolia/AlgoliaDsl.scala
+++ b/src/main/scala/algolia/AlgoliaDsl.scala
@@ -92,8 +92,12 @@ object AlgoliaDsl extends AlgoliaDsl {
       new LocalDateTimeSerializer +
       new ZonedDateTimeSerializer +
       new AlternativesSerializer +
-      new FieldSerializer[IndexSettings](deserializer = numericAttributesToIndexDeserializer) +
-      new FieldSerializer[DeleteObjectOperation[JValue]](serializer = deleteObjectOperationSerializer)
+      new FieldSerializer[IndexSettings](
+        deserializer = numericAttributesToIndexDeserializer
+      ) +
+      new FieldSerializer[DeleteObjectOperation[JValue]](
+        serializer = deleteObjectOperationSerializer
+      )
 
   val searchableAttributesUnordered: Regex = """^unordered\(([\w-\\.]+)\)$""".r
   val searchableAttributesAttributes: Regex =
@@ -418,7 +422,8 @@ object AlgoliaDsl extends AlgoliaDsl {
       )
   }
 
-  def deleteObjectOperationSerializer: PartialFunction[(String, Any), Option[(String, Any)]] = {
+  def deleteObjectOperationSerializer
+      : PartialFunction[(String, Any), Option[(String, Any)]] = {
     case "objectID" -> objectID => Some("body" -> ("objectID" -> objectID))
   }
 

--- a/src/test/scala/algolia/dsl/BatchTest.scala
+++ b/src/test/scala/algolia/dsl/BatchTest.scala
@@ -188,11 +188,11 @@ class BatchTest extends AlgoliaTest {
             |   "requests":[
             |     {
             |       "indexName":"test1",
-            |       "objectID":"1",
+            |       "body":{"objectID":"1"},
             |       "action":"deleteObject"
             |     },{
             |       "indexName":"test2",
-            |       "objectID":"2",
+            |       "body":{"objectID":"2"},
             |       "action":"deleteObject"
             |     }
             |   ]

--- a/src/test/scala/algolia/dsl/DeleteObjectTest.scala
+++ b/src/test/scala/algolia/dsl/DeleteObjectTest.scala
@@ -61,10 +61,10 @@ class DeleteObjectTest extends AlgoliaTest {
             | {
             |   "requests":[
             |     {
-            |       "objectID":"1",
+            |       "body":{"objectID":"1"},
             |       "action":"deleteObject"
             |     },{
-            |       "objectID":"2",
+            |       "body":{"objectID":"2"},
             |       "action":"deleteObject"
             |     }
             |   ]


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | ~yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | n/a
| Need Doc update   | no


## Describe your change

Move `DeleteObjectOperation` serialization:
from`{"action":"deleteObject","objectID":"toto"}`
to `{"action":"deleteObject","body":{"objectID":"toto"}}` 
