### PR TITLE
shutdown DNS event loop when closing HTTP client

### DIFF
--- a/src/main/scala/algolia/AlgoliaHttpClient.scala
+++ b/src/main/scala/algolia/AlgoliaHttpClient.scala
@@ -26,8 +26,8 @@
 package algolia
 
 import java.util.concurrent.ExecutionException
-
 import algolia.http._
+import io.netty.channel.EventLoop
 import io.netty.channel.nio.NioEventLoopGroup
 import io.netty.channel.socket.nio.NioDatagramChannel
 import io.netty.resolver.dns.{DnsNameResolver, DnsNameResolverBuilder}
@@ -51,8 +51,9 @@ case class AlgoliaHttpClient(
       .setRequestTimeout(configuration.httpRequestTimeoutMs)
       .build
 
+  val dnsEventLoop: EventLoop = new NioEventLoopGroup(1).next()
   val dnsNameResolver: DnsNameResolver =
-    new DnsNameResolverBuilder(new NioEventLoopGroup(1).next()) //We only need 1 thread for DNS resolution
+    new DnsNameResolverBuilder(dnsEventLoop) //We only need 1 thread for DNS resolution
       .channelType(classOf[NioDatagramChannel])
       .queryTimeoutMillis(configuration.dnsTimeoutMs.toLong)
       .maxQueriesPerResolve(2)
@@ -66,6 +67,7 @@ case class AlgoliaHttpClient(
 
   def close(): Unit = {
     dnsNameResolver.close()
+    dnsEventLoop.shutdownGracefully()
     _httpClient.close()
   }
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #650 
| Need Doc update   | no


## Describe your change
Shutdown internal thread when closing `AlgoliaHttpClient`.

## What problem is this fixing?
Fixing issue #650 