### PR TITLE
fea: allow use of system proxy

### DIFF
--- a/src/main/scala/algolia/AlgoliaClientConfiguration.scala
+++ b/src/main/scala/algolia/AlgoliaClientConfiguration.scala
@@ -32,7 +32,7 @@ case class AlgoliaClientConfiguration(
     httpRequestTimeoutMs: Int,
     dnsTimeoutMs: Int,
     hostDownTimeoutMs: Int,
-    useSystemProxy: Boolean
+    useSystemProxy: Boolean = false
 ) {}
 
 object AlgoliaClientConfiguration {
@@ -42,7 +42,6 @@ object AlgoliaClientConfiguration {
     httpReadTimeoutMs = 2 * 1000,
     httpRequestTimeoutMs = 2 * 1000,
     dnsTimeoutMs = 2 * 100, //200 ms
-    hostDownTimeoutMs = 5 * 60 * 1000,
-    useSystemProxy = false
+    hostDownTimeoutMs = 5 * 60 * 1000
   )
 }

--- a/src/main/scala/algolia/AlgoliaClientConfiguration.scala
+++ b/src/main/scala/algolia/AlgoliaClientConfiguration.scala
@@ -31,7 +31,8 @@ case class AlgoliaClientConfiguration(
     httpReadTimeoutMs: Int,
     httpRequestTimeoutMs: Int,
     dnsTimeoutMs: Int,
-    hostDownTimeoutMs: Int
+    hostDownTimeoutMs: Int,
+    useSystemProxy: Boolean
 ) {}
 
 object AlgoliaClientConfiguration {
@@ -41,6 +42,7 @@ object AlgoliaClientConfiguration {
     httpReadTimeoutMs = 2 * 1000,
     httpRequestTimeoutMs = 2 * 1000,
     dnsTimeoutMs = 2 * 100, //200 ms
-    hostDownTimeoutMs = 5 * 60 * 1000
+    hostDownTimeoutMs = 5 * 60 * 1000,
+    useSystemProxy = false
   )
 }

--- a/src/main/scala/algolia/AlgoliaHttpClient.scala
+++ b/src/main/scala/algolia/AlgoliaHttpClient.scala
@@ -49,6 +49,7 @@ case class AlgoliaHttpClient(
       .setConnectTimeout(configuration.httpConnectTimeoutMs)
       .setReadTimeout(configuration.httpReadTimeoutMs)
       .setRequestTimeout(configuration.httpRequestTimeoutMs)
+      .setUseProxyProperties(configuration.useSystemProxy)
       .build
 
   val dnsNameResolver: DnsNameResolver =

--- a/src/test/scala/algolia/dsl/PartialUpdateObjectTest.scala
+++ b/src/test/scala/algolia/dsl/PartialUpdateObjectTest.scala
@@ -223,6 +223,10 @@ class PartialUpdateObjectTest extends AlgoliaTest {
       )
     }
 
+    it ("sample") {
+      partialUpdate from "productIndex" createIfNotExists() objects()
+    }
+
     it("should call API") {
       (partialUpdate from "index" `object` BasicObjectWithObjectID(
         "name1",


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | n/A  <!-- will close issue automatically, if any -->
| Need Doc update   | yes/no


## Describe your change

Allow the use of system proxy like for [Java client](https://www.algolia.com/doc/guides/getting-started/quick-start/tutorials/quick-start-with-the-api-client/java/?language=java&client=java#proxy):
```scala
// create client configuration
val config = new AlgoliaClientConfiguration(
  //...
  useSystemProxy = true
)
// or
val config = AlgoliaClientConfiguration.default.copy(useSystemProxy = true)
// instantiate the API client with the configuration
val client = new AlgoliaClient("APPID", "APIKEY", configuration = config)
```