### PR TITLE
similarQuery not accounted for in param string

### DIFF
--- a/src/main/scala/algolia/objects/Query.scala
+++ b/src/main/scala/algolia/objects/Query.scala
@@ -210,6 +210,7 @@ case class Query(
       /* Search */
       "query" -> query,
       "facetQuery" -> facetQuery,
+      "similarQuery" -> similarQuery,
       /* Typos */
       "minWordSizefor1Typo" -> minWordSizefor1Typo.map(_.toString),
       "minWordSizefor2Typos" -> minWordSizefor2Typos.map(_.toString),

--- a/src/test/scala/algolia/dsl/SearchTest.scala
+++ b/src/test/scala/algolia/dsl/SearchTest.scala
@@ -276,10 +276,14 @@ class SearchTest extends AlgoliaTest {
     it("should parametrize stuff") {
       val q = Query(
         query = Some(""),
-        similarQuery = Some("\"test phrase\"")
+        similarQuery = Some("\"test phrase\""),
+        advancedSyntax = Some(true),
+        advancedSyntaxFeatures = Some(Seq("exactPhrase"))
       )
 
-      q.toParam should be("query=&similarQuery=%22test+phrase%22")
+      q.toParam should be(
+        "advancedSyntax=true&query=&advancedSyntaxFeatures=exactPhrase&similarQuery=%22test+phrase%22"
+      )
     }
   }
 }

--- a/src/test/scala/algolia/dsl/SearchTest.scala
+++ b/src/test/scala/algolia/dsl/SearchTest.scala
@@ -272,4 +272,14 @@ class SearchTest extends AlgoliaTest {
     }
   }
 
+  describe("search with similarQuery") {
+    it("should parametrize stuff") {
+      val q = Query(
+        query = Some(""),
+        similarQuery = Some("\"test phrase\"")
+      )
+
+      q.toParam should be("query=&similarQuery=%22test+phrase%22")
+    }
+  }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #...  <!-- will close issue automatically, if any -->
| Need Doc update   | maybe


## Describe your change

Add similarQuery to params sent to Algolia.

## What problem is this fixing?

While similarQuery is exposed by the Query class type, it isn't used when it comes time to build the params string. The result is that similarQuery isn't sent to Algolia during execution.