### PR TITLE
fix(search): add facet stats object

### DIFF
--- a/src/main/scala/algolia/objects/FacetStats.scala
+++ b/src/main/scala/algolia/objects/FacetStats.scala
@@ -1,0 +1,8 @@
+package algolia.objects
+
+case class FacetStats (
+  min: Float,
+  max: Float,
+  avg: Option[Float] = None,
+  sum: Option[Float] = None
+)

--- a/src/main/scala/algolia/responses/SearchResult.scala
+++ b/src/main/scala/algolia/responses/SearchResult.scala
@@ -25,7 +25,7 @@
 
 package algolia.responses
 
-import algolia.objects.{AbstractSynonym, RenderingContent, Rule}
+import algolia.objects.{AbstractSynonym, FacetStats, RenderingContent, Rule}
 import org.json4s._
 
 private[algolia] trait SearchHits[A] {
@@ -50,7 +50,7 @@ case class SearchResult(
     message: Option[String],
     aroundLatLng: Option[String],
     automaticRadius: Option[String],
-    facets_stats: Option[Map[String, Float]],
+    facets_stats: Option[Map[String, FacetStats]],
     // For getRankingInfo
     serverUsed: Option[String],
     parsedQuery: Option[String],


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix [CR-5918](https://algolia.atlassian.net/browse/CR-5918)
| Need Doc update   | no


## Describe your change

Introduce the FacetStats object and update the SearchResult class to leverage it

## What problem is this fixing?

The `facet_stats` property was poorly typed


[CR-5918]: https://algolia.atlassian.net/browse/CR-5918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ